### PR TITLE
[medium-risk] [no-ticket] ci(release): manual dispatch + allow-list + production environment gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,45 @@
+# CODEOWNERS for gtv-desktop-remote
+#
+# Syntax: <path-pattern>  <@owner> [<@owner> ...]
+# Docs:   https://docs.github.com/repositories/managing-your-repositories-settings-and-customizations/customizing-your-repository/about-code-owners
+#
+# How this is enforced:
+#   This file only *declares* ownership. For changes to actually require a
+#   Code Owner's review, the `main` branch must have a protection rule with
+#   "Require review from Code Owners" enabled in
+#   Settings → Branches → Branch protection rules → main.
+#
+# Why these paths in particular:
+#   The Release workflow, CI workflow, semantic-release config, husky hooks,
+#   and any helper scripts that touch release/deploy plumbing are
+#   security-sensitive: an unreviewed edit to any of them could bypass the
+#   manual-dispatch + production-environment gates that lock down releases.
+#   Forcing @usrivastava92's review here closes that loophole.
+
+# Default fallback — any file not matched below still requires the repo owner.
+*                                @usrivastava92
+
+# ── Release & CI plumbing ────────────────────────────────────────────────────
+/.github/                        @usrivastava92
+/.github/workflows/              @usrivastava92
+/.github/workflows/release.yml   @usrivastava92
+/.github/workflows/ci.yml        @usrivastava92
+/.github/CODEOWNERS              @usrivastava92
+
+# ── semantic-release / commitlint / husky ────────────────────────────────────
+/.releaserc.json                 @usrivastava92
+/commitlint.config.ts            @usrivastava92
+/.husky/                         @usrivastava92
+
+# ── Release scripts & helpers ────────────────────────────────────────────────
+/bin/                            @usrivastava92
+/bin/release                     @usrivastava92
+/scripts/                        @usrivastava92
+/scripts/render-homebrew-cask.mjs @usrivastava92
+
+# ── Build / packaging config ─────────────────────────────────────────────────
+/package.json                    @usrivastava92
+/package-lock.json               @usrivastava92
+/electron-builder*               @usrivastava92
+/tsconfig*.json                  @usrivastava92
+/vite.config.ts                  @usrivastava92

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,30 @@
 name: Release
 
-# Triggered on every push to main and via workflow_dispatch.
+# Manually-triggered release pipeline.
 #
-# Job 1 (build-macos): runs semantic-release --dry-run to find out if this
-#   push warrants a new version. If yes, patches package.json with the next
-#   version, builds the macOS DMG + ZIP, and uploads them as workflow artifacts.
+# Releases used to fire on every push to `main`, which produced a new
+# GitHub Release per commit. They are now manual: batch up commits on `main`
+# and trigger this workflow when you want to cut a release. The recommended
+# way to do so is via the `bin/release` script (or `npm run release`), which
+# previews the next version locally and then dispatches this workflow.
 #
-# Job 2 (release): runs the real semantic-release, downloads the DMG + ZIP artifacts,
-#   and attaches them to the GitHub Release.
+# Job 1 (build-macos): runs semantic-release --dry-run to find out if the
+#   selected ref warrants a new version. If yes, patches package.json with the
+#   next version, builds the macOS DMG + ZIP, and uploads them as workflow
+#   artifacts.
+#
+# Job 2 (release): runs the real semantic-release, downloads the DMG + ZIP
+#   artifacts, and attaches them to the GitHub Release.
 #
 # GITHUB_TOKEN is provided automatically by GitHub Actions — no secret needed.
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Optional note for this manual release (shown in the run summary).'
+        required: false
+        default: ''
 
 concurrency:
   group: release-${{ github.ref }}
@@ -24,15 +33,56 @@ concurrency:
 permissions:
   contents: write
 
+# Comma-separated GitHub usernames that are allowed to trigger this workflow.
+# This is a fast-fail "first line" check — the real, GitHub-enforced gate is
+# the `environment: production` on each job, which requires an approver
+# configured in repo Settings → Environments → production.
+env:
+  RELEASE_ALLOWED_ACTORS: 'usrivastava92'
+
 jobs:
+  # ── Job 0: actor allow-list preflight ────────────────────────────────────
+  # Cheap, immediate check so an unauthorized dispatch fails in seconds
+  # instead of sitting in the environment approvals queue.
+  authorize:
+    name: Authorize actor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check triggering actor against allow-list
+        env:
+          ACTOR: ${{ github.triggering_actor }}
+          ALLOWED: ${{ env.RELEASE_ALLOWED_ACTORS }}
+        run: |
+          echo "Triggered by: $ACTOR"
+          echo "Allow-list:   $ALLOWED"
+          # Comma- or whitespace-separated list match.
+          if printf '%s' ",$ALLOWED," | tr -d ' ' | grep -q ",${ACTOR},"; then
+            echo "✓ $ACTOR is authorized to trigger releases."
+          else
+            echo "✗ $ACTOR is NOT in RELEASE_ALLOWED_ACTORS." >&2
+            echo "  Update the allow-list in .github/workflows/release.yml" >&2
+            echo "  if this user should be able to cut releases." >&2
+            exit 1
+          fi
+
   # ── Job 1: build macOS artifacts ──────────────────────────────────────────
   build-macos:
     name: Build macOS artifacts
     runs-on: macos-latest
+    needs: authorize
+    # GitHub-enforced gate: this job will not start until a reviewer configured
+    # on the `production` environment (Settings → Environments → production)
+    # clicks "Approve and run". Environment secrets (e.g. HOMEBREW_TAP_TOKEN)
+    # should live on this environment so they cannot leak to unapproved runs.
+    environment: production
     outputs:
       next-version: ${{ steps.dry-run.outputs.version }}
       will-release: ${{ steps.dry-run.outputs.will_release }}
     steps:
+      - name: Record trigger reason
+        if: ${{ inputs.reason != '' }}
+        run: echo "Manual release reason — ${{ inputs.reason }}" >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -114,6 +164,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-macos
     if: needs.build-macos.outputs.will-release == 'true'
+    # Same hard gate as build-macos. In practice this job inherits the
+    # approval that was granted to build-macos within the same run, so you
+    # only have to approve once per release.
+    environment: production
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
 node_modules
 dist
 dist-electron
-release
+# electron-builder output directory — anchored & trailing slash so it only
+# matches the top-level build output, not files named "release" elsewhere
+# in the tree (e.g. bin/release).
+/release/
 build
 .DS_Store
+
+# Belt-and-braces: explicitly un-ignore the release helper script.
+!/bin/release
 
 # graphify - ignore generated outputs by default, then allow portable outputs
 graphify-out/*

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -132,11 +132,98 @@ This is intentional so short navigation bursts remain responsive while sustained
 
 ## Release Workflow
 
-This project uses `electron-builder` for packaging.
+Releases are produced by the `Release` GitHub Actions workflow
+(`.github/workflows/release.yml`), driven by
+[semantic-release](https://semantic-release.gitbook.io/) and
+[Conventional Commits](https://www.conventionalcommits.org/). Packaging is
+handled by `electron-builder`.
 
-- CI validates install, typecheck, and build
-- Tagged releases are intended to produce macOS artifacts
-- The current target platform is macOS
+### Manual, batched releases
+
+The workflow is **manually triggered** — it no longer fires on every push to
+`main`. This lets you batch several commits into a single release instead of
+producing a new GitHub Release per commit.
+
+Use the helper script:
+
+```bash
+# Preview the next version from commits on origin/main, then prompt before
+# triggering the Release workflow on GitHub:
+npm run release
+
+# Just preview locally, do not trigger CI:
+npm run release:dry-run
+
+# Skip the confirmation prompt (e.g. for use in other automation):
+bin/release --yes
+
+# Trigger against a non-main ref:
+bin/release --ref some-branch
+```
+
+The script will:
+
+1. Verify you are in a clean checkout that is in sync with `origin/<ref>`.
+2. List the commits that will be included since the last release tag.
+3. Run `semantic-release --dry-run` locally to compute and display the next
+   version (based on `feat:` / `fix:` / `BREAKING CHANGE:` etc.).
+4. Ask for confirmation, then dispatch the `Release` workflow via the `gh`
+   CLI (falling back to a REST call if `gh` is unavailable and
+   `GH_TOKEN`/`GITHUB_TOKEN` is set).
+5. Optionally tail the workflow run with `gh run watch`.
+
+You can also trigger the workflow directly from the GitHub Actions UI
+("Run workflow" on the `Release` workflow), but the script is preferred because
+it shows the next version and commit list before you commit to publishing.
+
+### What CI does on each push
+
+- The `CI` workflow validates install, typecheck, lint, format, and build for
+  every push and pull request.
+- The `Release` workflow only runs on manual dispatch and is responsible for
+  building the macOS DMG + ZIP, running semantic-release, and updating the
+  Homebrew tap.
+
+### Who can trigger a release
+
+The `Release` workflow is locked down with **two layers**:
+
+1. **Actor allow-list (fast-fail).** The `authorize` job in `release.yml`
+   reads `RELEASE_ALLOWED_ACTORS` and fails the run immediately if the
+   triggering user is not on the list. Update this env var in the workflow
+   file (in a PR you review) to grant or revoke access.
+2. **GitHub Environment approval (hard, GitHub-enforced).** Both jobs declare
+   `environment: production`. GitHub will pause the run and require an
+   approval from a configured reviewer before any build, publish, or
+   Homebrew-tap update step runs.
+
+#### One-time setup for the `production` environment
+
+In the repo on GitHub:
+
+1. **Settings → Environments → New environment** → name it `production`.
+2. Enable **Required reviewers** and add yourself (and only yourself, or
+   whoever should be able to approve releases).
+3. Under **Deployment branches and tags**, choose "Selected branches and
+   tags" and add `main` (so releases can only be approved from `main`).
+4. Move release-sensitive secrets onto this environment instead of the
+   repository-wide secrets:
+   - `HOMEBREW_TAP_TOKEN` → **Environment secrets** of `production`.
+   - (Optional) `HOMEBREW_TAP_REPOSITORY` → **Environment variables** of
+     `production`.
+
+   This guarantees the secret is only injected after you click "Approve and
+   run", so an unauthorized or accidental dispatch cannot exfiltrate it.
+
+After this setup, the flow for a release is:
+
+1. Someone (you) runs `npm run release` or "Run workflow" in the Actions UI.
+2. `authorize` job runs in seconds and either fails (unauthorized) or
+   succeeds.
+3. The run pauses with a "Review required" banner — GitHub emails the
+   reviewer(s).
+4. You click **Approve and run** → `build-macos` and `release` proceed and
+   publish exactly one GitHub Release for the batched commits.
 
 ## Homebrew Cask Releases
 

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# bin/release — Manually trigger the Release GitHub Actions workflow.
+#
+# The repo uses semantic-release with Conventional Commits. Previously the
+# workflow ran on every push to `main`, which produced a new release per commit.
+# Now releases are manual: you batch up commits on `main` and run this script
+# (or the corresponding `npm run release` alias) when you want to cut a release.
+#
+# What it does:
+#   1. Sanity-checks your local environment (git repo, clean tree, on main,
+#      and main is in sync with origin/main).
+#   2. Previews the next version semantic-release will compute from the
+#      Conventional Commits since the last tag (a local dry-run).
+#   3. Triggers the `Release` workflow on GitHub via `gh workflow run` (or
+#      prints the curl/REST equivalent if `gh` is not installed).
+#   4. Optionally tails the freshly started workflow run with `gh run watch`.
+#
+# Usage:
+#   bin/release                       # interactive, prompts for confirmation
+#   bin/release --yes                 # skip the confirmation prompt
+#   bin/release --ref <branch|sha>    # trigger on a non-main ref (rare)
+#   bin/release --dry-run             # only run the local dry-run, do not trigger CI
+#   bin/release --no-watch            # do not tail the workflow run after triggering
+#   bin/release --allow-dirty         # do not fail if working tree is dirty
+#   bin/release --allow-behind        # do not fail if local is behind origin
+#   bin/release -h | --help           # show help
+#
+# Requirements:
+#   - bash, git
+#   - npx (ships with Node) for the local semantic-release dry-run
+#   - gh CLI (https://cli.github.com) authenticated against this repo, OR a
+#     GH_TOKEN/GITHUB_TOKEN environment variable for the REST fallback
+#
+set -euo pipefail
+
+# ── Pretty output helpers ────────────────────────────────────────────────────
+if [ -t 1 ]; then
+  C_RESET=$'\033[0m'; C_BOLD=$'\033[1m'
+  C_RED=$'\033[31m'; C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'; C_BLUE=$'\033[34m'
+else
+  C_RESET=''; C_BOLD=''; C_RED=''; C_GREEN=''; C_YELLOW=''; C_BLUE=''
+fi
+
+info()  { printf '%s==>%s %s\n'  "$C_BLUE"   "$C_RESET" "$*"; }
+ok()    { printf '%s✓%s %s\n'    "$C_GREEN"  "$C_RESET" "$*"; }
+warn()  { printf '%s!%s %s\n'    "$C_YELLOW" "$C_RESET" "$*" >&2; }
+fail()  { printf '%s✗%s %s\n'    "$C_RED"    "$C_RESET" "$*" >&2; exit 1; }
+
+show_help() {
+  sed -n '2,/^set -euo pipefail$/p' "$0" | sed -E 's/^# ?//' | sed '$d'
+}
+
+# ── Defaults / argument parsing ──────────────────────────────────────────────
+REF="main"
+WORKFLOW="Release"        # workflow `name:` in .github/workflows/release.yml
+ASSUME_YES="false"
+DRY_RUN_ONLY="false"
+WATCH="true"
+ALLOW_DIRTY="false"
+ALLOW_BEHIND="false"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help)        show_help; exit 0 ;;
+    -y|--yes)         ASSUME_YES="true"; shift ;;
+    --dry-run)        DRY_RUN_ONLY="true"; shift ;;
+    --no-watch)       WATCH="false"; shift ;;
+    --allow-dirty)    ALLOW_DIRTY="true"; shift ;;
+    --allow-behind)   ALLOW_BEHIND="true"; shift ;;
+    --ref)            REF="${2:-}"; [ -n "$REF" ] || fail "--ref requires a value"; shift 2 ;;
+    --ref=*)          REF="${1#--ref=}"; shift ;;
+    --workflow)       WORKFLOW="${2:-}"; [ -n "$WORKFLOW" ] || fail "--workflow requires a value"; shift 2 ;;
+    --workflow=*)     WORKFLOW="${1#--workflow=}"; shift ;;
+    *)                fail "Unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+# ── Move to repo root ────────────────────────────────────────────────────────
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$REPO_ROOT" ] || fail "Not inside a git repository."
+cd "$REPO_ROOT"
+
+# ── Determine remote slug (owner/repo) ───────────────────────────────────────
+REMOTE_URL=$(git config --get remote.origin.url 2>/dev/null || true)
+[ -n "$REMOTE_URL" ] || fail "No 'origin' remote configured."
+
+# Normalise both SSH and HTTPS forms into "owner/repo".
+SLUG=$(printf '%s' "$REMOTE_URL" \
+  | sed -E 's#^git@github\.com:#https://github.com/#' \
+  | sed -E 's#^https://github\.com/##' \
+  | sed -E 's#\.git$##')
+[ -n "$SLUG" ] || fail "Could not parse owner/repo from origin URL: $REMOTE_URL"
+
+# ── Pre-flight checks ────────────────────────────────────────────────────────
+info "Repository:  $C_BOLD$SLUG$C_RESET"
+info "Target ref:  $C_BOLD$REF$C_RESET"
+info "Workflow:    $C_BOLD$WORKFLOW$C_RESET"
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$REF" = "main" ] && [ "$CURRENT_BRANCH" != "main" ]; then
+  warn "You are on '$CURRENT_BRANCH', not 'main'. The workflow will still run against '$REF' on the remote."
+fi
+
+if [ "$ALLOW_DIRTY" = "false" ]; then
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    fail "Working tree is dirty. Commit/stash changes, or pass --allow-dirty."
+  fi
+fi
+
+info "Fetching latest refs from origin..."
+git fetch --tags --prune origin >/dev/null 2>&1 || warn "git fetch failed — continuing with local state."
+
+if [ "$ALLOW_BEHIND" = "false" ] && git rev-parse --verify "origin/$REF" >/dev/null 2>&1; then
+  LOCAL_SHA=$(git rev-parse "$REF" 2>/dev/null || echo "")
+  REMOTE_SHA=$(git rev-parse "origin/$REF")
+  if [ -n "$LOCAL_SHA" ] && [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then
+    BEHIND=$(git rev-list --left-right --count "$LOCAL_SHA...$REMOTE_SHA" | awk '{print $2}')
+    if [ "${BEHIND:-0}" -gt 0 ]; then
+      fail "Local '$REF' is $BEHIND commit(s) behind 'origin/$REF'. Pull first, or pass --allow-behind."
+    fi
+  fi
+fi
+
+# ── Show commits that will be included in this release ──────────────────────
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+info "Commits since last release ($C_BOLD${LAST_TAG:-<none>}$C_RESET) on origin/$REF:"
+if [ -n "$LAST_TAG" ]; then
+  git log --no-merges --pretty=format:'  • %h %s' "$LAST_TAG..origin/$REF" || true
+else
+  git log --no-merges --pretty=format:'  • %h %s' "origin/$REF" | head -n 50 || true
+fi
+echo
+
+# ── Local semantic-release dry-run to preview next version ──────────────────
+info "Running semantic-release --dry-run to preview the next version..."
+DRY_OUTPUT_FILE=$(mktemp -t gtv-release-dryrun.XXXXXX)
+trap 'rm -f "$DRY_OUTPUT_FILE"' EXIT
+
+if ! npx --no-install semantic-release --dry-run --no-ci >"$DRY_OUTPUT_FILE" 2>&1; then
+  # semantic-release exits non-zero when there is nothing to release; not fatal.
+  warn "semantic-release dry-run exited non-zero. Output below:"
+fi
+sed -n '1,120p' "$DRY_OUTPUT_FILE" | sed 's/^/   /'
+
+NEXT_VERSION=$(sed -nE 's/.*next release version is ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' "$DRY_OUTPUT_FILE" | head -n 1 || true)
+if [ -n "$NEXT_VERSION" ]; then
+  ok "Next version will be: $C_BOLD$NEXT_VERSION$C_RESET"
+else
+  warn "No releasable commits detected since last tag — triggering the workflow will produce no new release."
+fi
+
+if [ "$DRY_RUN_ONLY" = "true" ]; then
+  ok "Dry-run only: not triggering CI."
+  exit 0
+fi
+
+# ── Confirmation prompt ──────────────────────────────────────────────────────
+if [ "$ASSUME_YES" != "true" ]; then
+  printf '\n%sTrigger the %s workflow on %s @ %s? [y/N] %s' \
+    "$C_BOLD" "$WORKFLOW" "$SLUG" "$REF" "$C_RESET"
+  read -r ANSWER || ANSWER=""
+  case "$ANSWER" in
+    y|Y|yes|YES) ;;
+    *) fail "Aborted." ;;
+  esac
+fi
+
+# ── Trigger the workflow ─────────────────────────────────────────────────────
+trigger_with_gh() {
+  info "Triggering via gh CLI..."
+  gh workflow run "$WORKFLOW" --repo "$SLUG" --ref "$REF"
+}
+
+trigger_with_curl() {
+  local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  [ -n "$token" ] || fail "gh CLI not found and neither GH_TOKEN nor GITHUB_TOKEN is set."
+  info "Triggering via REST API (curl)..."
+  # Look up the workflow file name from the workflow display name.
+  local wf_file
+  wf_file=$(basename "$(grep -lE "^name:\s*$WORKFLOW\b" .github/workflows/*.yml 2>/dev/null | head -n 1)")
+  [ -n "$wf_file" ] || fail "Could not locate workflow file for '$WORKFLOW' in .github/workflows/."
+
+  curl -fsSL \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $token" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/$SLUG/actions/workflows/$wf_file/dispatches" \
+    -d "{\"ref\":\"$REF\"}"
+}
+
+if command -v gh >/dev/null 2>&1; then
+  trigger_with_gh
+else
+  trigger_with_curl
+fi
+ok "Workflow dispatch sent."
+
+# ── Optionally watch the run ─────────────────────────────────────────────────
+if [ "$WATCH" = "true" ] && command -v gh >/dev/null 2>&1; then
+  info "Waiting for the new run to appear..."
+  RUN_ID=""
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 2
+    RUN_ID=$(gh run list --repo "$SLUG" --workflow "$WORKFLOW" --branch "$REF" \
+              --limit 1 --json databaseId,status \
+              --jq '.[0] | select(.status!="completed") | .databaseId' 2>/dev/null || true)
+    [ -n "$RUN_ID" ] && break
+  done
+
+  if [ -n "$RUN_ID" ]; then
+    ok "Tailing run #$RUN_ID (Ctrl-C to detach; the run will keep going)..."
+    gh run watch "$RUN_ID" --repo "$SLUG" --exit-status || true
+  else
+    warn "Could not locate the new run within 20s. Check it manually: https://github.com/$SLUG/actions"
+  fi
+else
+  info "View runs: https://github.com/$SLUG/actions/workflows/release.yml"
+fi

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "typecheck": "tsc --noEmit && tsc -p tsconfig.electron.json --noEmit",
     "reset:app": "node scripts/reset-app-state.mjs",
     "reset:app:dry-run": "node scripts/reset-app-state.mjs --dry-run",
+    "release": "bin/release",
+    "release:dry-run": "bin/release --dry-run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary

Switches the release pipeline from "1 release per push" to **batched, manual, gated releases**.

Releases used to fire on every push to `main`, producing a new GitHub Release per commit. Now:
- Commits batch up on `main` via normal PRs.
- A maintainer runs `npm run release` when they want to cut a release.
- The workflow is locked down so only authorized users can trigger it, and even they must explicitly approve the run.

## What changes

### `.github/workflows/release.yml`
- Removed `push: branches: [main]` trigger.
- Added optional `reason` input on `workflow_dispatch` (shown in run summary).
- New `authorize` job — fails in ~5s if `github.triggering_actor` is not in `RELEASE_ALLOWED_ACTORS`.
- Both `build-macos` and `release` declare `environment: production`, which is GitHub-enforced: the run pauses until a reviewer on that environment clicks **Approve and run** before any build, publish, or Homebrew-tap update happens.
- `HOMEBREW_TAP_TOKEN` (secret) and `HOMEBREW_TAP_REPOSITORY` (variable) now live on the `production` environment, so they cannot be read by an unapproved run.

### `bin/release` (new, executable) — exposed as `npm run release`
- Verifies a clean checkout in sync with `origin/<ref>`.
- Lists commits since the last release tag.
- Runs `semantic-release --dry-run` locally to preview the next version.
- Prompts, then dispatches the `Release` workflow via `gh` CLI (REST `curl` fallback when `gh` is unavailable and `GH_TOKEN`/`GITHUB_TOKEN` is set).
- Tails the new run with `gh run watch`.
- Flags: `--dry-run`, `--yes`, `--no-watch`, `--ref`, `--workflow`, `--allow-dirty`, `--allow-behind`, `--help`.

### `.github/CODEOWNERS` (new)
Forces `@usrivastava92` review on the release-sensitive surface:
- `/.github/` (workflows + CODEOWNERS itself)
- `.releaserc.json`, `commitlint.config.ts`, `.husky/`
- `/bin/`, `/scripts/`
- `package.json`, `package-lock.json`, build/TS/Vite configs
- `*` fallback

Combined with the existing `main` ruleset (`require_code_owner_review: true`), nobody can quietly remove the allow-list or environment gate without owner approval.

### `.gitignore`
- Anchored the `release` rule as `/release/` so it only matches the top-level electron-builder output dir, not `bin/release`.
- Added explicit `!/bin/release` belt-and-braces.

### `package.json`
- `npm run release` runs `bin/release`
- `npm run release:dry-run` runs `bin/release --dry-run`

### `DEVELOPMENT.md`
- Documented the new manual + batched flow, the actor allow-list, and the one-time `production` environment setup (required reviewers, scoped secrets/variables, branch restriction).

## How releases work after this PR

1. PRs land on `main` as usual (CI still runs on every push/PR).
2. When ready to ship: `npm run release` shows the next version, prompt to confirm.
3. `authorize` job runs (~5s) and either fails (unauthorized) or proceeds.
4. Run pauses with "Review required" and the maintainer clicks **Approve and run**.
5. Build + semantic-release run once and produce one GitHub Release plus one Homebrew tap commit for the batch.

## Pre-merge checklist (already done in repo settings)

- [x] `production` environment created with required reviewer = `@usrivastava92`
- [x] `production` deployment-branches restricted to `main`
- [x] `HOMEBREW_TAP_TOKEN` stored as an environment secret on `production`
- [x] `HOMEBREW_TAP_REPOSITORY` stored as an environment variable on `production`
- [x] `main` ruleset already enforces PR + Code Owner review (verified)

## Risk

`medium-risk`: changes the release-trigger contract and adds approval gating, but is fully reversible (revert the workflow file) and has no impact on application code or CI of regular PRs.

## Test plan

1. After merge, on `main`: `npm run release:dry-run` should report next version or "no releasable commits".
2. `npm run release` should show the commit list, then pause on the `production` approval gate.
3. Approve and expect exactly one new GitHub Release and one commit in `usrivastava92/homebrew-tap`.
4. From a non-allow-listed account, dispatching via the UI should make the `authorize` job fail immediately.
