### PR TITLE
[low-risk] [NO-JIRA] refactor: introduce factory functions for bridge + metrics singletons

### DIFF
--- a/src/main/device/androidTvRemote.ts
+++ b/src/main/device/androidTvRemote.ts
@@ -453,7 +453,7 @@ class NativeRemoteClient {
   }
 }
 
-class AndroidTvRemoteBridge {
+export class AndroidTvRemoteBridge {
   private readonly sessions = new Map<string, DeviceSession>();
 
   private getStateDir(): string {
@@ -768,4 +768,15 @@ class AndroidTvRemoteBridge {
   }
 }
 
-export const androidTvRemoteBridge = new AndroidTvRemoteBridge();
+/**
+ * Factory: construct a fresh bridge. New code (PR-5 onward) should prefer this
+ * over the singleton so each test gets an isolated session map. Production code
+ * continues to use the `androidTvRemoteBridge` singleton below for backward
+ * compatibility.
+ */
+export function createAndroidTvRemoteBridge(): AndroidTvRemoteBridge {
+  return new AndroidTvRemoteBridge();
+}
+
+// Existing process-wide singleton — preserved for backward compatibility.
+export const androidTvRemoteBridge = createAndroidTvRemoteBridge();

--- a/src/main/metrics.ts
+++ b/src/main/metrics.ts
@@ -51,7 +51,7 @@ function createEmptySnapshot(): CommandMetricsSnapshot {
   };
 }
 
-class CommandMetricsStore {
+export class CommandMetricsStore {
   private readonly commands = new Map<string, CommandMetricsRecord>();
 
   private readonly counters = createCounters();
@@ -448,7 +448,7 @@ class CommandMetricsStore {
 }
 
 /* eslint-disable @typescript-eslint/no-empty-function */
-class NoopCommandMetricsStore {
+export class NoopCommandMetricsStore {
   recordRendererDrop(_report: CommandDropReport): void {}
 
   recordIpcReceived(_request: CommandDispatchRequest): void {}
@@ -497,6 +497,25 @@ class NoopCommandMetricsStore {
 }
 /* eslint-enable @typescript-eslint/no-empty-function */
 
-export const commandMetricsStore = isDebugTelemetryEnabled()
-  ? new CommandMetricsStore()
-  : new NoopCommandMetricsStore();
+/**
+ * Factory: construct a fresh metrics store for tests or future composition
+ * roots. Production code continues to use the `commandMetricsStore` singleton
+ * below; new code (PR-5 onward) should prefer this factory + dependency
+ * injection. Pass `forceEnabled=true` to bypass the debug-telemetry flag.
+ */
+export function createCommandMetricsStore(
+  forceEnabled?: boolean
+): CommandMetricsStore | NoopCommandMetricsStore {
+  if (forceEnabled === true) {
+    return new CommandMetricsStore();
+  }
+  if (forceEnabled === false) {
+    return new NoopCommandMetricsStore();
+  }
+  return isDebugTelemetryEnabled() ? new CommandMetricsStore() : new NoopCommandMetricsStore();
+}
+
+// Existing process-wide singleton — preserved for backward compatibility. All
+// existing call sites continue to work unchanged. Prefer the factory above for
+// new code and tests.
+export const commandMetricsStore = createCommandMetricsStore();


### PR DESCRIPTION
## Wave 1 / QW-3 — Drop module-level singletons in favor of factories

Tiny seam-introduction PR from the Quick Wins group in [`REFACTOR_PLAN.md`](https://github.com/usrivastava92/gtv-desktop-remote/blob/main/REFACTOR_PLAN.md). **Zero behavior change.**

### What this PR does

Adds factory functions alongside the two module-level singletons that PR-5 (`AppFacade`) and the service-extraction PRs need to be able to construct fresh instances of:

- **`src/main/device/androidTvRemote.ts`**
  - Exports the `AndroidTvRemoteBridge` class.
  - New: `createAndroidTvRemoteBridge()` factory.
  - The existing `androidTvRemoteBridge` singleton is preserved — it now calls the factory internally.

- **`src/main/metrics.ts`**
  - Exports both `CommandMetricsStore` and `NoopCommandMetricsStore` classes.
  - New: `createCommandMetricsStore(forceEnabled?)` factory that respects the debug-telemetry flag by default and can override it for tests.
  - The existing `commandMetricsStore` singleton is preserved.

### Why

Right now `AndroidTvRemoteBridge` and `CommandMetricsStore` are *only* accessible as process-wide singletons. This blocks per-test isolation (every test that touches them shares state) and forces every call site to import the singleton instead of receiving its dependency. PR-5 (`AppFacade`) will compose fresh instances; this PR introduces the seam **without changing any production behavior**.

### Local validation

```
✅ npm test           → 2/2 passed
✅ npm run typecheck  → clean
✅ npm run lint       → 0 errors (4 pre-existing warnings unrelated)
✅ npm run format:check → clean
✅ npm run build      → clean
```

### Risk

**Low.** Every existing import (`import { androidTvRemoteBridge } from './androidTvRemote';` and `import { commandMetricsStore } from './metrics';`) keeps working byte-for-byte. The new factories are pure additions.

### Diff size

+37 / -7 lines across 2 files — well under the 600-LOC PR budget.

### Checklist

- [x] Tests pass locally
- [x] Lint clean (0 errors on changed code)
- [x] Typecheck clean across renderer + electron + backend tsconfigs
- [x] No behavior change to packaged app
- [x] Conforms to plan in `REFACTOR_PLAN.md` §5 Group B / §7.2 Wave 1
