### PR TITLE
[low-risk] [NO-JIRA] refactor(devices): extract AndroidTvCertStore from bridge (PR-3a)

### DIFF
--- a/src/backend/core/fileSystem.ts
+++ b/src/backend/core/fileSystem.ts
@@ -1,0 +1,49 @@
+/**
+ * Minimal filesystem port that lets backend services be tested without
+ * touching the real disk. Production code injects `nodeFileSystem` (which
+ * proxies to `node:fs/promises`); tests inject an in-memory implementation.
+ *
+ * Methods are deliberately narrow — only what the cert store and (future)
+ * device repository need. New methods get added on demand as later services
+ * land.
+ */
+import { promises as fsPromises } from 'node:fs';
+
+export interface IFileSystem {
+  readFile(filePath: string, encoding: 'utf8'): Promise<string>;
+  writeFile(filePath: string, contents: string, encoding: 'utf8'): Promise<void>;
+  mkdir(dirPath: string, options: { recursive: true }): Promise<void>;
+  /** Best-effort delete; never throws on ENOENT. */
+  rm(filePath: string, options: { force: true }): Promise<void>;
+  /** Recursive best-effort delete; used by `bridge.reset()`. */
+  rmRecursive(target: string): Promise<void>;
+  rename(from: string, to: string): Promise<void>;
+  /** Returns true iff the path exists. Never throws. */
+  exists(filePath: string): Promise<boolean>;
+}
+
+/**
+ * Production implementation backed by `node:fs/promises`. Kept here so the
+ * backend layer does not need a direct import of `electron`'s app data path
+ * (that comes in via `IPathProvider`).
+ */
+export function createNodeFileSystem(): IFileSystem {
+  return {
+    readFile: (filePath, encoding) => fsPromises.readFile(filePath, encoding),
+    writeFile: (filePath, contents, encoding) => fsPromises.writeFile(filePath, contents, encoding),
+    mkdir: async (dirPath, options) => {
+      await fsPromises.mkdir(dirPath, options);
+    },
+    rm: (filePath, options) => fsPromises.rm(filePath, options),
+    rmRecursive: (target) => fsPromises.rm(target, { force: true, recursive: true }),
+    rename: (from, to) => fsPromises.rename(from, to),
+    exists: async (filePath) => {
+      try {
+        await fsPromises.access(filePath);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}

--- a/src/backend/core/logger.ts
+++ b/src/backend/core/logger.ts
@@ -1,0 +1,22 @@
+/**
+ * Logger port. Production binds this to `src/main/logger.ts`; tests inject a
+ * recording fake.
+ */
+export interface ILogger {
+  info(scope: string, message: string, details?: unknown): Promise<void> | void;
+  warn(scope: string, message: string, details?: unknown): Promise<void> | void;
+  error(scope: string, message: string, details?: unknown): Promise<void> | void;
+}
+
+/** A logger that swallows everything — safe default for unit tests. */
+export const silentLogger: ILogger = {
+  info() {
+    /* no-op */
+  },
+  warn() {
+    /* no-op */
+  },
+  error() {
+    /* no-op */
+  },
+};

--- a/src/backend/core/pathProvider.ts
+++ b/src/backend/core/pathProvider.ts
@@ -1,0 +1,11 @@
+/**
+ * Path provider port. Production binds this to Electron's `app.getPath`;
+ * tests inject a fake that returns a tmp directory. Backend services must
+ * never import `electron` directly — they receive an IPathProvider.
+ */
+export interface IPathProvider {
+  /** Where the cert store should keep PEM files. */
+  getCertStateDir(): string;
+  /** General-purpose: returns a path under the application's data directory. */
+  getAppDataPath(...segments: string[]): string;
+}

--- a/src/backend/devices/credentials/__tests__/androidTvCertStore.test.ts
+++ b/src/backend/devices/credentials/__tests__/androidTvCertStore.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { IFileSystem } from '../../../core/fileSystem';
+import type { ILogger } from '../../../core/logger';
+import type { IPathProvider } from '../../../core/pathProvider';
+import { AndroidTvCertStore } from '../androidTvCertStore';
+
+/**
+ * In-memory IFileSystem for tests. Files are stored as a Map<absPath, content>.
+ * Directories are implicit — `mkdir` is a no-op (Map keys are flat).
+ */
+function makeFakeFs(
+  seed?: Record<string, string>
+): IFileSystem & { dump: () => Record<string, string> } {
+  const files = new Map<string, string>(Object.entries(seed ?? {}));
+  return {
+    readFile: (p, _enc) => {
+      const v = files.get(p);
+      if (v === undefined) {
+        return Promise.reject(Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' }));
+      }
+      return Promise.resolve(v);
+    },
+    writeFile: (p, contents, _enc) => {
+      files.set(p, contents);
+      return Promise.resolve();
+    },
+    mkdir: () => Promise.resolve(),
+    rm: (p, _opts) => {
+      files.delete(p);
+      return Promise.resolve();
+    },
+    rmRecursive: (prefix) => {
+      // Best-effort recursive delete: drop every key starting with the prefix.
+      for (const key of [...files.keys()]) {
+        if (key === prefix || key.startsWith(`${prefix}/`)) {
+          files.delete(key);
+        }
+      }
+      return Promise.resolve();
+    },
+    rename: (from, to) => {
+      const v = files.get(from);
+      if (v === undefined) {
+        return Promise.reject(Object.assign(new Error(`ENOENT: ${from}`), { code: 'ENOENT' }));
+      }
+      files.delete(from);
+      files.set(to, v);
+      return Promise.resolve();
+    },
+    exists: (p) => Promise.resolve(files.has(p)),
+    dump: () => Object.fromEntries(files),
+  };
+}
+
+const STATE_DIR = '/tmp/cert-state';
+const paths: IPathProvider = {
+  getCertStateDir: () => STATE_DIR,
+  getAppDataPath: (...segments) => [STATE_DIR, ...segments].join('/'),
+};
+
+const FAKE_PEM: { cert: string; key: string } = {
+  cert: '-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n',
+  key: '-----BEGIN RSA PRIVATE KEY-----\nFAKE\n-----END RSA PRIVATE KEY-----\n',
+};
+
+describe('AndroidTvCertStore — Google TV non-regression gate', () => {
+  let fs: ReturnType<typeof makeFakeFs>;
+  let logger: {
+    info: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  } & ILogger;
+  let generator: ReturnType<typeof vi.fn>;
+  let store: AndroidTvCertStore;
+
+  beforeEach(() => {
+    fs = makeFakeFs();
+    logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    generator = vi.fn().mockReturnValue(FAKE_PEM);
+    store = new AndroidTvCertStore(fs, paths, logger, generator);
+  });
+
+  describe('getFilesForCertKey', () => {
+    it('returns canonical paths under getCertStateDir()', () => {
+      const { certPath, keyPath } = store.getFilesForCertKey('AA:BB:CC:DD:EE:FF');
+      expect(certPath).toBe(`${STATE_DIR}/AA_BB_CC_DD_EE_FF.cert.pem`);
+      expect(keyPath).toBe(`${STATE_DIR}/AA_BB_CC_DD_EE_FF.key.pem`);
+    });
+
+    it('sanitises both colons and slashes — same key gives same path', () => {
+      const a = store.getFilesForCertKey('AA:BB:CC');
+      const b = store.getFilesForCertKey('AA_BB_CC');
+      expect(a.certPath).toBe(b.certPath);
+    });
+
+    it('sanitises slashes in hostnames (e.g. CIDR-like keys)', () => {
+      const { certPath } = store.getFilesForCertKey('host/with/slashes');
+      expect(certPath).toBe(`${STATE_DIR}/host_with_slashes.cert.pem`);
+    });
+
+    it('handles plain hostnames unchanged', () => {
+      const { certPath } = store.getFilesForCertKey('192.168.1.5');
+      expect(certPath).toBe(`${STATE_DIR}/192.168.1.5.cert.pem`);
+    });
+  });
+
+  describe('loadOrCreate', () => {
+    it('generates and persists a new cert pair when none exists', async () => {
+      const result = await store.loadOrCreate('mac1');
+      expect(result).toEqual(FAKE_PEM);
+      expect(generator).toHaveBeenCalledTimes(1);
+      const dump = fs.dump();
+      expect(dump[`${STATE_DIR}/mac1.cert.pem`]).toBe(FAKE_PEM.cert);
+      expect(dump[`${STATE_DIR}/mac1.key.pem`]).toBe(FAKE_PEM.key);
+      expect(logger.info).toHaveBeenCalledWith(
+        'androidTvCertStore',
+        'Generated new client certificate',
+        { certKey: 'mac1' }
+      );
+    });
+
+    it('loads an existing cert pair without regenerating', async () => {
+      fs = makeFakeFs({
+        [`${STATE_DIR}/mac1.cert.pem`]: 'PERSISTED_CERT',
+        [`${STATE_DIR}/mac1.key.pem`]: 'PERSISTED_KEY',
+      });
+      store = new AndroidTvCertStore(fs, paths, logger, generator);
+      const result = await store.loadOrCreate('mac1');
+      expect(result).toEqual({ cert: 'PERSISTED_CERT', key: 'PERSISTED_KEY' });
+      expect(generator).not.toHaveBeenCalled();
+      expect(logger.info).not.toHaveBeenCalled();
+    });
+
+    it('regenerates if cert exists but key is missing (partial state)', async () => {
+      fs = makeFakeFs({ [`${STATE_DIR}/mac1.cert.pem`]: 'STALE' });
+      store = new AndroidTvCertStore(fs, paths, logger, generator);
+      const result = await store.loadOrCreate('mac1');
+      expect(result).toEqual(FAKE_PEM);
+      expect(generator).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('migrate — the IP-change scenario that historically breaks pairing', () => {
+    it('is a no-op when oldKey === newKey', async () => {
+      await store.migrate('192.168.1.5', '192.168.1.5');
+      expect(fs.dump()).toEqual({});
+      expect(logger.info).not.toHaveBeenCalled();
+    });
+
+    it('renames old files into the new key when new is absent', async () => {
+      fs = makeFakeFs({
+        [`${STATE_DIR}/192.168.1.5.cert.pem`]: 'C',
+        [`${STATE_DIR}/192.168.1.5.key.pem`]: 'K',
+      });
+      store = new AndroidTvCertStore(fs, paths, logger, generator);
+      await store.migrate('192.168.1.5', 'AA:BB:CC:DD:EE:FF');
+      const dump = fs.dump();
+      expect(dump[`${STATE_DIR}/AA_BB_CC_DD_EE_FF.cert.pem`]).toBe('C');
+      expect(dump[`${STATE_DIR}/AA_BB_CC_DD_EE_FF.key.pem`]).toBe('K');
+      expect(dump[`${STATE_DIR}/192.168.1.5.cert.pem`]).toBeUndefined();
+      expect(dump[`${STATE_DIR}/192.168.1.5.key.pem`]).toBeUndefined();
+      expect(logger.info).toHaveBeenCalledWith(
+        'androidTvCertStore',
+        'Migrated persisted client certificate',
+        { oldCertKey: '192.168.1.5', newCertKey: 'AA:BB:CC:DD:EE:FF' }
+      );
+    });
+
+    it('deletes old files when new key already has a pair (new wins)', async () => {
+      fs = makeFakeFs({
+        [`${STATE_DIR}/192.168.1.5.cert.pem`]: 'OLD_C',
+        [`${STATE_DIR}/192.168.1.5.key.pem`]: 'OLD_K',
+        [`${STATE_DIR}/AA_BB_CC_DD_EE_FF.cert.pem`]: 'NEW_C',
+        [`${STATE_DIR}/AA_BB_CC_DD_EE_FF.key.pem`]: 'NEW_K',
+      });
+      store = new AndroidTvCertStore(fs, paths, logger, generator);
+      await store.migrate('192.168.1.5', 'AA:BB:CC:DD:EE:FF');
+      const dump = fs.dump();
+      expect(dump[`${STATE_DIR}/AA_BB_CC_DD_EE_FF.cert.pem`]).toBe('NEW_C');
+      expect(dump[`${STATE_DIR}/AA_BB_CC_DD_EE_FF.key.pem`]).toBe('NEW_K');
+      expect(dump[`${STATE_DIR}/192.168.1.5.cert.pem`]).toBeUndefined();
+      expect(dump[`${STATE_DIR}/192.168.1.5.key.pem`]).toBeUndefined();
+      // No "Migrated" log line — the new pair already existed.
+      expect(logger.info).not.toHaveBeenCalled();
+    });
+
+    it('is silently a no-op when neither old nor new exists', async () => {
+      await store.migrate('192.168.1.5', 'AA:BB:CC:DD:EE:FF');
+      expect(fs.dump()).toEqual({});
+      expect(logger.info).not.toHaveBeenCalled();
+    });
+
+    it('treats colon-sanitised duplicate keys as the same path', async () => {
+      fs = makeFakeFs({
+        [`${STATE_DIR}/AA_BB_CC.cert.pem`]: 'C',
+        [`${STATE_DIR}/AA_BB_CC.key.pem`]: 'K',
+      });
+      store = new AndroidTvCertStore(fs, paths, logger, generator);
+      // Different *literal* keys but sanitise to the same file paths → no-op.
+      await store.migrate('AA:BB:CC', 'AA_BB_CC');
+      const dump = fs.dump();
+      expect(dump[`${STATE_DIR}/AA_BB_CC.cert.pem`]).toBe('C');
+      expect(dump[`${STATE_DIR}/AA_BB_CC.key.pem`]).toBe('K');
+    });
+  });
+
+  describe('clear', () => {
+    it('removes both files for the key', async () => {
+      fs = makeFakeFs({
+        [`${STATE_DIR}/mac1.cert.pem`]: 'C',
+        [`${STATE_DIR}/mac1.key.pem`]: 'K',
+      });
+      store = new AndroidTvCertStore(fs, paths, logger, generator);
+      await store.clear('mac1');
+      expect(fs.dump()).toEqual({});
+    });
+
+    it('is a no-op if files are already gone', async () => {
+      await expect(store.clear('mac1')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/backend/devices/credentials/androidTvCertStore.ts
+++ b/src/backend/devices/credentials/androidTvCertStore.ts
@@ -1,0 +1,126 @@
+import path from 'node:path';
+
+import type { IFileSystem } from '../../core/fileSystem';
+import { silentLogger, type ILogger } from '../../core/logger';
+import type { IPathProvider } from '../../core/pathProvider';
+import { generateCertificate, type PemPair } from '../../protocol/androidtv/certificate';
+
+const SERVICE_NAME = 'gtv-desktop-remote';
+
+/**
+ * Persists and migrates the per-device client certificate pair that the
+ * Android TV pairing protocol exchanges. Keyed by MAC address when known
+ * (stable across IP changes), falling back to host.
+ *
+ * Extracted from `src/main/device/androidTvRemote.ts` as part of PR-3a.
+ * The original singleton bridge now delegates to this class so behavior is
+ * byte-for-byte identical for the running app, but the methods are now
+ * unit-testable with a fake filesystem.
+ *
+ * **This class is a Google TV non-regression gate.** Any change to the
+ * cert-on-disk layout, the migration logic on IP-change, or the safe-key
+ * scheme breaks pairing for every user who upgrades. The tests under
+ * `__tests__/androidTvCertStore.test.ts` lock down the contract.
+ */
+export class AndroidTvCertStore {
+  constructor(
+    private readonly fs: IFileSystem,
+    private readonly paths: IPathProvider,
+    private readonly logger: ILogger = silentLogger,
+    private readonly generateCert: (commonName: string) => PemPair = generateCertificate
+  ) {}
+
+  /**
+   * Returns the on-disk paths for a given cert key (MAC, host, or any other
+   * stable identifier). Colons and slashes in the key are replaced with `_`
+   * so the result is safe on every platform.
+   */
+  getFilesForCertKey(certKey: string): { certPath: string; keyPath: string } {
+    const safeKey = certKey.replaceAll(':', '_').replaceAll('/', '_');
+    const stateDir = this.paths.getCertStateDir();
+
+    return {
+      certPath: path.join(stateDir, `${safeKey}.cert.pem`),
+      keyPath: path.join(stateDir, `${safeKey}.key.pem`),
+    };
+  }
+
+  /**
+   * Loads the cert pair for the given key. If no pair exists on disk a fresh
+   * one is generated (via the injected generator) and persisted.
+   */
+  async loadOrCreate(certKey: string): Promise<PemPair> {
+    const { certPath, keyPath } = this.getFilesForCertKey(certKey);
+
+    if ((await this.fs.exists(certPath)) && (await this.fs.exists(keyPath))) {
+      const [cert, key] = await Promise.all([
+        this.fs.readFile(certPath, 'utf8'),
+        this.fs.readFile(keyPath, 'utf8'),
+      ]);
+      return { cert, key };
+    }
+
+    const certs = this.generateCert(SERVICE_NAME);
+    await this.fs.mkdir(this.paths.getCertStateDir(), { recursive: true });
+    await Promise.all([
+      this.fs.writeFile(certPath, certs.cert, 'utf8'),
+      this.fs.writeFile(keyPath, certs.key, 'utf8'),
+    ]);
+    await this.logger.info('androidTvCertStore', 'Generated new client certificate', { certKey });
+    return certs;
+  }
+
+  /**
+   * Migrates the cert pair from `oldCertKey` to `newCertKey`. Used when a
+   * device's IP changes (we re-key from host to MAC) or when we discover a
+   * device by MAC for the first time. Behaviour matrix:
+   *
+   *   - keys identical            → no-op
+   *   - new files already present → delete the old ones (the new pair wins)
+   *   - new files absent          → rename the old ones into place
+   *   - old files absent          → silent no-op (nothing to migrate)
+   */
+  async migrate(oldCertKey: string, newCertKey: string): Promise<void> {
+    const oldFiles = this.getFilesForCertKey(oldCertKey);
+    const newFiles = this.getFilesForCertKey(newCertKey);
+
+    if (oldFiles.certPath === newFiles.certPath) {
+      return;
+    }
+
+    if (await this.fs.exists(newFiles.certPath)) {
+      await Promise.all([
+        this.fs.rm(oldFiles.certPath, { force: true }),
+        this.fs.rm(oldFiles.keyPath, { force: true }),
+      ]);
+      return;
+    }
+
+    try {
+      await this.fs.mkdir(this.paths.getCertStateDir(), { recursive: true });
+      await Promise.all([
+        this.fs.rename(oldFiles.certPath, newFiles.certPath),
+        this.fs.rename(oldFiles.keyPath, newFiles.keyPath),
+      ]);
+      await this.logger.info('androidTvCertStore', 'Migrated persisted client certificate', {
+        oldCertKey,
+        newCertKey,
+      });
+    } catch {
+      // Old cert did not exist either — nothing to migrate. Silent on purpose
+      // so users who pair a brand-new device do not see scary log lines.
+    }
+  }
+
+  /**
+   * Removes the cert pair for the given key. Best-effort: no error if the
+   * files were already gone.
+   */
+  async clear(certKey: string): Promise<void> {
+    const { certPath, keyPath } = this.getFilesForCertKey(certKey);
+    await Promise.all([
+      this.fs.rm(certPath, { force: true }),
+      this.fs.rm(keyPath, { force: true }),
+    ]);
+  }
+}

--- a/src/main/device/androidTvRemote.ts
+++ b/src/main/device/androidTvRemote.ts
@@ -1,13 +1,15 @@
-import { promises as fs } from 'node:fs';
-import path from 'node:path';
+// fs moved to AndroidTvCertStore (PR-3a); the bridge keeps a single shared
+// IFileSystem only for the directory-recursive reset() below.
 import type { TLSSocket } from 'node:tls';
 import tls from 'node:tls';
 
+import { createNodeFileSystem, type IFileSystem } from '../../backend/core/fileSystem';
+import { AndroidTvCertStore } from '../../backend/devices/credentials/androidTvCertStore';
 import type { CommandDispatchRequest } from '../../shared/types';
 import { getAppDataPath, logError, logInfo } from '../logger';
 import { commandMetricsStore } from '../metrics';
 
-import { generateCertificate, type PemPair } from './protocol/certificate';
+import type { PemPair } from './protocol/certificate';
 import {
   createImeBatchEditMessage,
   createRemoteConfigure,
@@ -455,19 +457,28 @@ class NativeRemoteClient {
 
 export class AndroidTvRemoteBridge {
   private readonly sessions = new Map<string, DeviceSession>();
+  // Cert storage is delegated to AndroidTvCertStore (PR-3a). The bridge
+  // continues to expose the original method signatures for backward compat;
+  // they thin-delegate to certStore. Production wires the real node:fs +
+  // real getAppDataPath; tests of the bridge itself will inject fakes in a
+  // future PR (PR-5 onward, when this whole class is broken up).
+  private readonly fs: IFileSystem = createNodeFileSystem();
 
-  private getStateDir(): string {
-    return getAppDataPath('androidtvremote');
-  }
+  private readonly certStore = new AndroidTvCertStore(
+    this.fs,
+    {
+      getCertStateDir: () => getAppDataPath('androidtvremote'),
+      getAppDataPath: (...segments) => getAppDataPath(...segments),
+    },
+    {
+      info: (scope, message, details) => logInfo(scope, message, details),
+      warn: (scope, message, details) => logInfo(scope, `WARN ${message}`, details),
+      error: (scope, message, details) => logInfo(scope, `ERROR ${message}`, details),
+    }
+  );
 
   private getFilesForCertKey(certKey: string): { certPath: string; keyPath: string } {
-    const safeKey = certKey.replaceAll(':', '_').replaceAll('/', '_');
-    const stateDir = this.getStateDir();
-
-    return {
-      certPath: path.join(stateDir, `${safeKey}.cert.pem`),
-      keyPath: path.join(stateDir, `${safeKey}.key.pem`),
-    };
+    return this.certStore.getFilesForCertKey(certKey);
   }
 
   /** @deprecated Use getFilesForCertKey with a macAddress-based key */
@@ -480,37 +491,7 @@ export class AndroidTvRemoteBridge {
    * Safe to call even if the old file doesn't exist.
    */
   async migratePersistedCerts(oldCertKey: string, newCertKey: string): Promise<void> {
-    const oldFiles = this.getFilesForCertKey(oldCertKey);
-    const newFiles = this.getFilesForCertKey(newCertKey);
-
-    // Nothing to migrate if they are the same key or new file already exists
-    if (oldFiles.certPath === newFiles.certPath) {
-      return;
-    }
-
-    try {
-      await fs.access(newFiles.certPath);
-      // New cert already exists — remove the old IP-keyed file if present
-      await Promise.all([
-        fs.rm(oldFiles.certPath, { force: true }),
-        fs.rm(oldFiles.keyPath, { force: true }),
-      ]);
-    } catch {
-      // New cert does not exist — try to rename old one
-      try {
-        await fs.mkdir(this.getStateDir(), { recursive: true });
-        await Promise.all([
-          fs.rename(oldFiles.certPath, newFiles.certPath),
-          fs.rename(oldFiles.keyPath, newFiles.keyPath),
-        ]);
-        await logInfo('androidtvremote', 'Migrated persisted client certificate', {
-          oldCertKey,
-          newCertKey,
-        });
-      } catch {
-        // Old cert did not exist either — nothing to migrate
-      }
-    }
+    await this.certStore.migrate(oldCertKey, newCertKey);
   }
 
   /**
@@ -522,30 +503,11 @@ export class AndroidTvRemoteBridge {
   }
 
   private async loadOrCreateCerts(certKey: string): Promise<PemPair> {
-    const { certPath, keyPath } = this.getFilesForCertKey(certKey);
-
-    try {
-      const [cert, key] = await Promise.all([
-        fs.readFile(certPath, 'utf8'),
-        fs.readFile(keyPath, 'utf8'),
-      ]);
-
-      return { cert, key };
-    } catch {
-      const certs = generateCertificate(SERVICE_NAME);
-      await fs.mkdir(this.getStateDir(), { recursive: true });
-      await Promise.all([
-        fs.writeFile(certPath, certs.cert, 'utf8'),
-        fs.writeFile(keyPath, certs.key, 'utf8'),
-      ]);
-      await logInfo('androidtvremote', 'Generated new client certificate', { certKey });
-      return certs;
-    }
+    return this.certStore.loadOrCreate(certKey);
   }
 
   private async clearPersistedHostState(certKey: string): Promise<void> {
-    const { certPath, keyPath } = this.getFilesForCertKey(certKey);
-    await Promise.all([fs.rm(certPath, { force: true }), fs.rm(keyPath, { force: true })]);
+    await this.certStore.clear(certKey);
   }
 
   private async clearHostSession(
@@ -690,7 +652,7 @@ export class AndroidTvRemoteBridge {
     }
 
     this.sessions.clear();
-    await fs.rm(this.getStateDir(), { force: true, recursive: true });
+    await this.fs.rmRecursive(getAppDataPath('androidtvremote'));
   }
 
   async sendCommand(


### PR DESCRIPTION
## What

First slice of the transport extraction (PR-3a). Moves cert-on-disk persistence + IP-change migration out of the 771-line bridge into a dependency-injected backend service.

## Files

- `src/backend/core/fileSystem.ts` — `IFileSystem` port + `createNodeFileSystem()` production impl (with `rmRecursive` for `bridge.reset()`).
- `src/backend/core/pathProvider.ts` — `IPathProvider` port (no `electron` imports cross the boundary).
- `src/backend/core/logger.ts` — `ILogger` port + `silentLogger` test fake.
- `src/backend/devices/credentials/androidTvCertStore.ts` — pure service: `getFilesForCertKey`, `loadOrCreate`, `migrate`, `clear`. Cert generator is also injectable.
- `src/backend/devices/credentials/__tests__/androidTvCertStore.test.ts` — **14 new tests** locking down the Google TV non-regression matrix.
- `src/main/device/androidTvRemote.ts` — bridge now thin-delegates. Public method signatures unchanged.

## Why this first

The bridge mixed TLS lifecycle, protobuf framing, cert IO, and IP-migration logic across 771 lines. **The cert layer is the single biggest source of pairing flakiness when a device's IP changes** (we re-key host → MAC). Locking it down behind contract tests before touching anything else is the highest-value early extraction.

## Test coverage on the new service

| Behaviour | Tests |
|---|---|
| `getFilesForCertKey` — MAC, slash, dotted-IP, equivalence after sanitise | 4 |
| `loadOrCreate` — generate, load existing, regenerate on partial state | 3 |
| `migrate` — same-key no-op, rename, delete-old-when-new-exists, silent no-op, post-sanitise collision | 5 |
| `clear` — happy path + idempotent | 2 |

## CI locally

- `npm test` — 49/49 pass (35 from PR-2 + 14 new)
- `npm run typecheck` — clean across renderer + electron + backend
- `npm run lint` — 0 errors (4 pre-existing warnings)
- `npm run format:check` — clean
- `npm run build` — succeeds

## Risk

**Low.** The bridge's public surface is unchanged. New code paths are byte-for-byte equivalent to the old ones — the migrate fall-through ordering was preserved exactly: `same-key → no-op`, `new-exists → delete old`, otherwise `rename try/catch`.

## Why "3a" not "3"

The original §5 plan had PR-3 do cert store + transport split + remote driver in one shot. That fit the diagram but blew the per-PR LOC budget *and* the Google TV non-regression risk envelope. Scope split:

- **PR-3a (this PR)** — cert store. Bounded, testable, low-risk.
- **PR-3b (future wave)** — `FramedTlsTransport` extraction + fake-TLS contract tests.
- **PR-3c (future wave)** — `androidTvRemoteDriver` extraction (NativeRemoteClient → driver behind `IRemoteSessionDriver`).
