### PR TITLE
[low-risk] [NO-JIRA] refactor(updater): extract pure version + asset helpers

### DIFF
--- a/src/backend/updater/__tests__/version.test.ts
+++ b/src/backend/updater/__tests__/version.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  compareVersions,
+  findBestMacAsset,
+  formatMinutesUntil,
+  isDmgAsset,
+  normalizeVersion,
+} from '../version';
+
+describe('normalizeVersion', () => {
+  it('strips a leading lowercase v', () => {
+    expect(normalizeVersion('v1.2.3')).toBe('1.2.3');
+  });
+
+  it('strips a leading uppercase V', () => {
+    expect(normalizeVersion('V0.8.0')).toBe('0.8.0');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeVersion('  v1.0.0\n')).toBe('1.0.0');
+  });
+
+  it('leaves a bare version untouched', () => {
+    expect(normalizeVersion('1.0.0')).toBe('1.0.0');
+  });
+
+  it('only strips a single leading v, not embedded ones', () => {
+    expect(normalizeVersion('v1.2v')).toBe('1.2v');
+  });
+});
+
+describe('compareVersions', () => {
+  it('returns 0 for identical versions', () => {
+    expect(compareVersions('1.2.3', '1.2.3')).toBe(0);
+  });
+
+  it('returns 0 for v-prefixed equality', () => {
+    expect(compareVersions('v1.2.3', '1.2.3')).toBe(0);
+  });
+
+  it('treats missing trailing segments as 0', () => {
+    expect(compareVersions('1.2', '1.2.0')).toBe(0);
+    expect(compareVersions('1', '1.0.0.0')).toBe(0);
+  });
+
+  it('orders by patch correctly', () => {
+    expect(compareVersions('1.2.4', '1.2.3')).toBe(1);
+    expect(compareVersions('1.2.3', '1.2.4')).toBe(-1);
+  });
+
+  it('orders by minor correctly', () => {
+    expect(compareVersions('1.3.0', '1.2.99')).toBe(1);
+  });
+
+  it('orders by major correctly', () => {
+    expect(compareVersions('2.0.0', '1.99.99')).toBe(1);
+  });
+
+  it('compares numerically, not lexically', () => {
+    expect(compareVersions('1.10.0', '1.9.0')).toBe(1);
+    expect(compareVersions('1.9.0', '1.10.0')).toBe(-1);
+  });
+
+  it('treats non-numeric segments as 0', () => {
+    expect(compareVersions('1.0.foo', '1.0.0')).toBe(0);
+  });
+
+  it('handles a longer version winning by extra non-zero segment', () => {
+    expect(compareVersions('1.2.3.1', '1.2.3')).toBe(1);
+    expect(compareVersions('1.2.3', '1.2.3.1')).toBe(-1);
+  });
+});
+
+describe('formatMinutesUntil', () => {
+  const NOW = 1_700_000_000;
+
+  it('returns "shortly" when the epoch is in the past', () => {
+    expect(formatMinutesUntil(NOW - 60, NOW)).toBe('shortly');
+  });
+
+  it('returns "shortly" when the epoch equals now', () => {
+    expect(formatMinutesUntil(NOW, NOW)).toBe('shortly');
+  });
+
+  it('returns "shortly" for NaN', () => {
+    expect(formatMinutesUntil(Number.NaN, NOW)).toBe('shortly');
+  });
+
+  it('returns "in about a minute" for ≤ 60s away', () => {
+    expect(formatMinutesUntil(NOW + 30, NOW)).toBe('in about a minute');
+    expect(formatMinutesUntil(NOW + 60, NOW)).toBe('in about a minute');
+  });
+
+  it('rounds up to the next minute for the 61–119s range', () => {
+    expect(formatMinutesUntil(NOW + 61, NOW)).toBe('in about 2 minutes');
+    expect(formatMinutesUntil(NOW + 119, NOW)).toBe('in about 2 minutes');
+  });
+
+  it('reports minutes for the < 60min range', () => {
+    expect(formatMinutesUntil(NOW + 30 * 60, NOW)).toBe('in about 30 minutes');
+    expect(formatMinutesUntil(NOW + 59 * 60, NOW)).toBe('in about 59 minutes');
+  });
+
+  it('uses the singular "hour" boundary', () => {
+    expect(formatMinutesUntil(NOW + 60 * 60, NOW)).toBe('in about 1 hour');
+  });
+
+  it('uses the plural "hours" boundary', () => {
+    expect(formatMinutesUntil(NOW + 2 * 60 * 60, NOW)).toBe('in about 2 hours');
+  });
+
+  it('defaults nowEpoch to Date.now() when omitted', () => {
+    // We can't pin Date.now without mocks; just assert the result is one of the
+    // valid shapes rather than a crash.
+    const future = Math.floor(Date.now() / 1000) + 120;
+    const result = formatMinutesUntil(future);
+    expect(['in about a minute', 'in about 2 minutes']).toContain(result);
+  });
+});
+
+describe('isDmgAsset', () => {
+  it('returns true for .dmg', () => {
+    expect(isDmgAsset({ name: 'foo-mac-arm64.dmg' })).toBe(true);
+  });
+
+  it('returns false for .zip', () => {
+    expect(isDmgAsset({ name: 'foo-mac-arm64.zip' })).toBe(false);
+  });
+
+  it('is case-sensitive (matches release naming)', () => {
+    expect(isDmgAsset({ name: 'foo-mac-arm64.DMG' })).toBe(false);
+  });
+});
+
+describe('findBestMacAsset — preference matrix', () => {
+  const assets = [
+    { name: 'gtv-desktop-remote-mac-arm64.zip' },
+    { name: 'gtv-desktop-remote-mac-x64.zip' },
+    { name: 'gtv-desktop-remote-mac-arm64.dmg' },
+    { name: 'gtv-desktop-remote-mac-x64.dmg' },
+    { name: 'gtv-desktop-remote-linux-x64.tar.gz' },
+  ];
+
+  it('picks the arch-matched zip for arm64', () => {
+    expect(findBestMacAsset(assets, 'arm64')?.name).toBe('gtv-desktop-remote-mac-arm64.zip');
+  });
+
+  it('picks the arch-matched zip for x64', () => {
+    expect(findBestMacAsset(assets, 'x64')?.name).toBe('gtv-desktop-remote-mac-x64.zip');
+  });
+
+  it('falls back to any mac zip when arch zip absent', () => {
+    const noArm = assets.filter((a) => a.name !== 'gtv-desktop-remote-mac-arm64.zip');
+    expect(findBestMacAsset(noArm, 'arm64')?.name).toBe('gtv-desktop-remote-mac-x64.zip');
+  });
+
+  it('falls back to arch-matched dmg when no zip exists', () => {
+    const onlyDmg = assets.filter((a) => a.name.endsWith('.dmg'));
+    expect(findBestMacAsset(onlyDmg, 'arm64')?.name).toBe('gtv-desktop-remote-mac-arm64.dmg');
+  });
+
+  it('falls back to any mac dmg when arch dmg absent', () => {
+    const onlyX64Dmg = [{ name: 'gtv-desktop-remote-mac-x64.dmg' }];
+    expect(findBestMacAsset(onlyX64Dmg, 'arm64')?.name).toBe('gtv-desktop-remote-mac-x64.dmg');
+  });
+
+  it('returns undefined when no mac asset exists', () => {
+    const linuxOnly = [{ name: 'gtv-desktop-remote-linux-x64.tar.gz' }];
+    expect(findBestMacAsset(linuxOnly, 'arm64')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty asset list', () => {
+    const empty: { name: string }[] = [];
+    const result = findBestMacAsset(empty, 'arm64');
+    expect(result).toBeUndefined();
+  });
+
+  it('ignores assets without the -mac- marker', () => {
+    // A bare `.zip` should not be picked up even if it has the right extension.
+    const tricky = [{ name: 'gtv-desktop-remote.zip' }, { name: 'gtv-desktop-remote.dmg' }];
+    expect(findBestMacAsset(tricky, 'arm64')).toBeUndefined();
+  });
+
+  it('defaults arch to process.arch when omitted', () => {
+    const result = findBestMacAsset(assets);
+    // Whatever the host arch is, the result must include `-mac-` and end with .zip
+    // (since both arch zips are present in our fixture).
+    expect(result?.name).toMatch(/-mac-(arm64|x64)\.zip$/);
+  });
+});

--- a/src/backend/updater/version.ts
+++ b/src/backend/updater/version.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure helpers extracted from `src/main/updater.ts` as part of PR-6.
+ *
+ * Nothing here touches Electron, the filesystem, or the network. The full
+ * updater (download / install / rollback orchestration) remains in
+ * `src/main/updater.ts` for now; that big slice is the subject of a future
+ * `PR-6b` wave once the FSM lives on top of these pure foundations.
+ *
+ * **Why this matters:** the updater historically mixed pure version comparison
+ * with side-effecting dialog calls and disk IO, which made it impossible to
+ * unit-test the "should we offer the new version?" decision. With these helpers
+ * lifted out and tested at 100%, regressions in semver comparison or rate-limit
+ * formatting cannot ship without a failing CI job.
+ */
+
+/** Minimal shape used by `findBestMacAsset`. Matches the GitHub releases API. */
+export interface ReleaseAssetInfo {
+  readonly name: string;
+}
+
+/** Strip a leading `v`/`V` and surrounding whitespace. */
+export function normalizeVersion(value: string): string {
+  return value.trim().replace(/^v/i, '');
+}
+
+/**
+ * Numeric semver-ish comparator. Each version is split on `.`, each segment is
+ * parsed as base-10 (non-numeric segments become 0), and segments are compared
+ * pair-wise. Missing trailing segments are treated as 0 so `1.2` === `1.2.0`.
+ *
+ * Returns:
+ *   1  if `a` > `b`
+ *  -1  if `a` < `b`
+ *   0  otherwise
+ */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  const aParts = normalizeVersion(a)
+    .split('.')
+    .map((part) => Number.parseInt(part, 10) || 0);
+  const bParts = normalizeVersion(b)
+    .split('.')
+    .map((part) => Number.parseInt(part, 10) || 0);
+
+  const max = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < max; i += 1) {
+    const left = aParts[i] ?? 0;
+    const right = bParts[i] ?? 0;
+    if (left > right) return 1;
+    if (left < right) return -1;
+  }
+
+  return 0;
+}
+
+/**
+ * Returns a human-friendly "in about X" string for the gap between `nowEpoch`
+ * and `epochSeconds`. Boundary handling:
+ *
+ *   - epoch is past, NaN, or 0           → "shortly"
+ *   - <= 60s away                        → "in about a minute"
+ *   - < 60min away                       → "in about N minutes"
+ *   - otherwise                          → "in about N hour(s)"
+ *
+ * `nowEpoch` is injected so tests don't need to freeze the system clock.
+ */
+export function formatMinutesUntil(
+  epochSeconds: number,
+  nowEpoch: number = Math.floor(Date.now() / 1000)
+): string {
+  const deltaSeconds = epochSeconds - nowEpoch;
+  if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0) {
+    return 'shortly';
+  }
+
+  const minutes = Math.ceil(deltaSeconds / 60);
+  if (minutes <= 1) {
+    return 'in about a minute';
+  }
+  if (minutes < 60) {
+    return `in about ${String(minutes)} minutes`;
+  }
+
+  const hours = Math.ceil(minutes / 60);
+  return `in about ${String(hours)} hour${hours > 1 ? 's' : ''}`;
+}
+
+/** True iff the asset ends in `.dmg` (case-sensitive — matches release naming). */
+export function isDmgAsset(asset: ReleaseAssetInfo): boolean {
+  return asset.name.endsWith('.dmg');
+}
+
+/**
+ * Pick the best macOS asset from a release. Preference matrix:
+ *
+ *   1. Architecture-matched `.zip`     (e.g. `app-mac-arm64.zip` when arch=arm64)
+ *   2. Any `-mac-*.zip`                (fallback for cross-arch installs)
+ *   3. Architecture-matched `.dmg`
+ *   4. Any `-mac-*.dmg`
+ *
+ * `arch` is injected (defaulting to `process.arch`) so tests can exercise both
+ * x64 and arm64 selection without spawning a different process.
+ *
+ * Returns `undefined` if no mac asset is present.
+ */
+export function findBestMacAsset<T extends ReleaseAssetInfo>(
+  assets: readonly T[],
+  arch: string = process.arch
+): T | undefined {
+  const preferredZip = assets.find((asset) => asset.name.endsWith(`-mac-${arch}.zip`));
+  if (preferredZip) return preferredZip;
+
+  const anyZip = assets.find(
+    (asset) => asset.name.includes('-mac-') && asset.name.endsWith('.zip')
+  );
+  if (anyZip) return anyZip;
+
+  const preferredDmg = assets.find((asset) => asset.name.endsWith(`-mac-${arch}.dmg`));
+  if (preferredDmg) return preferredDmg;
+
+  return assets.find((asset) => asset.name.includes('-mac-') && isDmgAsset(asset));
+}

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -6,6 +6,13 @@ import { promisify } from 'node:util';
 
 import { app, BrowserWindow, dialog, shell } from 'electron';
 
+import {
+  compareVersions,
+  findBestMacAsset,
+  formatMinutesUntil,
+  isDmgAsset,
+  normalizeVersion,
+} from '../backend/updater/version';
 import type { UpdaterStatus } from '../shared/types';
 
 import { getAppDataPath, logError, logInfo } from './logger';
@@ -89,28 +96,7 @@ async function showUpdaterDialog(
   return await dialog.showMessageBox(options);
 }
 
-function normalizeVersion(value: string) {
-  return value.trim().replace(/^v/i, '');
-}
-
-function compareVersions(a: string, b: string) {
-  const aParts = normalizeVersion(a)
-    .split('.')
-    .map((part) => Number.parseInt(part, 10) || 0);
-  const bParts = normalizeVersion(b)
-    .split('.')
-    .map((part) => Number.parseInt(part, 10) || 0);
-
-  const max = Math.max(aParts.length, bParts.length);
-  for (let i = 0; i < max; i += 1) {
-    const left = aParts[i] ?? 0;
-    const right = bParts[i] ?? 0;
-    if (left > right) return 1;
-    if (left < right) return -1;
-  }
-
-  return 0;
-}
+// normalizeVersion + compareVersions extracted to src/backend/updater/version.ts (PR-6).
 
 async function readUpdateState(): Promise<UpdateState> {
   const statePath = getAppDataPath('updater-state.json');
@@ -268,23 +254,7 @@ async function syncRollbackStatus() {
   return state;
 }
 
-function formatMinutesUntil(epochSeconds: number): string {
-  const deltaSeconds = epochSeconds - Math.floor(Date.now() / 1000);
-  if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0) {
-    return 'shortly';
-  }
-
-  const minutes = Math.ceil(deltaSeconds / 60);
-  if (minutes <= 1) {
-    return 'in about a minute';
-  }
-  if (minutes < 60) {
-    return `in about ${String(minutes)} minutes`;
-  }
-
-  const hours = Math.ceil(minutes / 60);
-  return `in about ${String(hours)} hour${hours > 1 ? 's' : ''}`;
-}
+// formatMinutesUntil extracted to src/backend/updater/version.ts (PR-6).
 
 async function requestJson<T>(url: string): Promise<T> {
   const controller = new AbortController();
@@ -336,25 +306,7 @@ async function requestJson<T>(url: string): Promise<T> {
   }
 }
 
-function isDmgAsset(asset: ReleaseAsset) {
-  return asset.name.endsWith('.dmg');
-}
-
-function findBestMacAsset(assets: ReleaseAsset[]) {
-  const arch = process.arch;
-  const preferredZip = assets.find((asset) => asset.name.endsWith(`-mac-${arch}.zip`));
-  if (preferredZip) return preferredZip;
-
-  const anyZip = assets.find(
-    (asset) => asset.name.includes('-mac-') && asset.name.endsWith('.zip')
-  );
-  if (anyZip) return anyZip;
-
-  const preferredDmg = assets.find((asset) => asset.name.endsWith(`-mac-${arch}.dmg`));
-  if (preferredDmg) return preferredDmg;
-
-  return assets.find((asset) => asset.name.includes('-mac-') && isDmgAsset(asset));
-}
+// isDmgAsset + findBestMacAsset extracted to src/backend/updater/version.ts (PR-6).
 
 function getBundlePathFromExecPath() {
   return path.resolve(process.execPath, '..', '..', '..');


### PR DESCRIPTION
## What

Scoped slice of the updater extraction (PR-6). Lifts pure helpers out of the 984-line `src/main/updater.ts` so they can be unit-tested without Electron, the filesystem, or the network.

## Files

- `src/backend/updater/version.ts` — 5 pure helpers (`normalizeVersion`, `compareVersions`, `formatMinutesUntil`, `isDmgAsset`, `findBestMacAsset`). Both `formatMinutesUntil` and `findBestMacAsset` now take their previously-implicit dependencies (current epoch, `process.arch`) as optional parameters, so tests are deterministic.
- `src/backend/updater/__tests__/version.test.ts` — **35 new tests** locking down semver ordering, time formatting boundaries, and the macOS asset preference matrix.
- `src/main/updater.ts` — re-uses the extracted helpers via import. Public exports unchanged.

## Why this slice and not the whole updater?

`updater.ts` weighs in at 984 lines and touches `electron.dialog`, `node:fs`, `node:child_process`, `fetch`, the cached release globals, and an in-memory `UpdaterStatus` singleton. Splitting it cleanly needs `IFileSystem` / `IShellRunner` / `IDialogPresenter` / `IReleaseSource` ports plus an `UpdateStateMachine` reducer — that's a PR-6b wave.

This PR is deliberately surgical: only the pure functions move, and they're tested at ~100% line coverage immediately. Risk near zero, value high (version comparison and asset selection are the two places "should we update?" decisions are made).

## CI locally

- `npm test` — 70/70 pass (35 new)
- `npm run typecheck` — clean across renderer + electron + backend
- `npm run lint` — 0 errors (4 pre-existing warnings)
- `npm run format:check` — clean
- `npm run build` — succeeds

## Risk

**Low.** The extracted functions are byte-for-byte equivalent to the originals; injected parameters default to the previous implicit values so all call sites in `updater.ts` continue to behave identically.

## Stack

- Lands on top of `main` (no dependency on PR-3a / PR #64). Either order is fine.
- Future PR-6b extracts `UpdateChecker` (rate-limit-aware GitHub fetch), `MacUpdateInstaller`, and `UpdateStateMachine`.
