### PR TITLE
[low-risk] [NO-JIRA] refactor(devices): extract DeviceRepository + DeviceRegistry (PR-4)

### DIFF
--- a/src/backend/devices/__tests__/deviceRegistry.test.ts
+++ b/src/backend/devices/__tests__/deviceRegistry.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DeviceDraft, DiscoveredDevice, SavedDevice } from '../../../shared/types';
+import {
+  findExistingForDraft,
+  identityChanged,
+  matchSavedToDiscovered,
+  mergeIdentity,
+  normalizeDraft,
+} from '../deviceRegistry';
+
+function saved(overrides: Partial<SavedDevice> = {}): SavedDevice {
+  return {
+    id: 'saved-1',
+    isPaired: true,
+    name: 'TV',
+    host: '192.168.1.5',
+    adbPort: 5555,
+    pairingPort: 6467,
+    ...overrides,
+  };
+}
+
+function discovered(overrides: Partial<DiscoveredDevice> = {}): DiscoveredDevice {
+  return {
+    id: 'disc-1',
+    host: '192.168.1.5',
+    ...overrides,
+  } as DiscoveredDevice;
+}
+
+function draft(overrides: Partial<DeviceDraft> = {}): DeviceDraft {
+  return {
+    name: 'TV',
+    host: '192.168.1.5',
+    adbPort: 5555,
+    pairingPort: 6467,
+    ...overrides,
+  };
+}
+
+describe('matchSavedToDiscovered — Google TV non-regression gate', () => {
+  describe('priority order: MAC > castDeviceId > networkHostName > fingerprint > host', () => {
+    it('matches by MAC when both sides have one (ignores host change)', () => {
+      const s = saved({ host: 'OLD', macAddress: 'AA:BB:CC' });
+      const d = discovered({ host: 'NEW', macAddress: 'AA:BB:CC' });
+      expect(matchSavedToDiscovered(s, [d])).toEqual(d);
+    });
+
+    it('falls through past MAC if either side lacks it', () => {
+      const s = saved({ macAddress: 'AA:BB:CC', castDeviceId: 'cast-1' });
+      // Discovered has no MAC, but does have matching castDeviceId.
+      const d = discovered({ castDeviceId: 'cast-1' });
+      expect(matchSavedToDiscovered(s, [d])).toEqual(d);
+    });
+
+    it('matches by castDeviceId when neither has MAC', () => {
+      const s = saved({ host: 'OLD', castDeviceId: 'cast-1' });
+      const d = discovered({ host: 'NEW', castDeviceId: 'cast-1' });
+      expect(matchSavedToDiscovered(s, [d])).toEqual(d);
+    });
+
+    it('matches by networkHostName when neither has MAC nor castDeviceId', () => {
+      const s = saved({ host: 'OLD', networkHostName: 'living-room.local' });
+      const d = discovered({ host: 'NEW', networkHostName: 'living-room.local' });
+      expect(matchSavedToDiscovered(s, [d])).toEqual(d);
+    });
+
+    it('matches by fingerprint ONLY when exactly one discovered device has it', () => {
+      const s = saved({ host: 'OLD', deviceFingerprint: 'fp-1' });
+      const d1 = discovered({ id: 'one', host: 'NEW', deviceFingerprint: 'fp-1' });
+      expect(matchSavedToDiscovered(s, [d1])).toEqual(d1);
+    });
+
+    it('does NOT match by fingerprint when multiple discovered devices have the same one', () => {
+      const s = saved({ host: 'NOT-FOUND', deviceFingerprint: 'fp-1' });
+      const d1 = discovered({ id: 'one', host: 'NEW-1', deviceFingerprint: 'fp-1' });
+      const d2 = discovered({ id: 'two', host: 'NEW-2', deviceFingerprint: 'fp-1' });
+      // Ambiguity → fall through to host match → neither host matches → undefined.
+      expect(matchSavedToDiscovered(s, [d1, d2])).toBeUndefined();
+    });
+
+    it('falls through to host match as a last resort', () => {
+      const s = saved({ host: '192.168.1.5' });
+      const d = discovered({ host: '192.168.1.5' });
+      expect(matchSavedToDiscovered(s, [d])).toEqual(d);
+    });
+
+    it('returns undefined when nothing matches', () => {
+      const s = saved({ host: '10.0.0.1' });
+      const d = discovered({ host: '192.168.1.5' });
+      expect(matchSavedToDiscovered(s, [d])).toBeUndefined();
+    });
+
+    it('returns undefined for an empty discovered list', () => {
+      expect(matchSavedToDiscovered(saved(), [])).toBeUndefined();
+    });
+  });
+});
+
+describe('mergeIdentity', () => {
+  it('preserves host when the match has the same host (backfill identity)', () => {
+    const s = saved({ host: '192.168.1.5' });
+    const d = discovered({
+      host: '192.168.1.5',
+      macAddress: 'AA:BB:CC',
+      castDeviceId: 'cast-1',
+    });
+    const result = mergeIdentity(s, d);
+    expect(result.host).toBe('192.168.1.5');
+    expect(result.macAddress).toBe('AA:BB:CC');
+    expect(result.castDeviceId).toBe('cast-1');
+    expect(result.isPaired).toBe(true); // preserved
+  });
+
+  it('does not overwrite existing identity fields on a same-host match', () => {
+    const s = saved({ host: '192.168.1.5', macAddress: 'EXISTING' });
+    const d = discovered({ host: '192.168.1.5', macAddress: 'NEW' });
+    expect(mergeIdentity(s, d).macAddress).toBe('EXISTING');
+  });
+
+  it('updates host when the match has a different host (IP change)', () => {
+    const s = saved({ host: 'OLD', macAddress: 'AA:BB:CC' });
+    const d = discovered({ host: 'NEW', macAddress: 'AA:BB:CC' });
+    const result = mergeIdentity(s, d);
+    expect(result.host).toBe('NEW');
+    expect(result.macAddress).toBe('AA:BB:CC');
+  });
+
+  it('backfills identity fields on an IP-change merge', () => {
+    const s = saved({ host: 'OLD' });
+    const d = discovered({
+      host: 'NEW',
+      macAddress: 'NEW-MAC',
+      castDeviceId: 'NEW-CAST',
+      networkHostName: 'new-host.local',
+      deviceFingerprint: 'NEW-FP',
+    });
+    const result = mergeIdentity(s, d);
+    expect(result).toMatchObject({
+      host: 'NEW',
+      macAddress: 'NEW-MAC',
+      castDeviceId: 'NEW-CAST',
+      networkHostName: 'new-host.local',
+      deviceFingerprint: 'NEW-FP',
+    });
+  });
+
+  it('preserves pairing state across an IP change', () => {
+    const s = saved({ host: 'OLD', isPaired: true });
+    const d = discovered({ host: 'NEW' });
+    expect(mergeIdentity(s, d).isPaired).toBe(true);
+  });
+});
+
+describe('identityChanged', () => {
+  it('returns false for identical devices', () => {
+    const a = saved();
+    const b = saved();
+    expect(identityChanged(a, b)).toBe(false);
+  });
+
+  it('detects host changes', () => {
+    expect(identityChanged(saved({ host: 'OLD' }), saved({ host: 'NEW' }))).toBe(true);
+  });
+
+  it('detects MAC backfill', () => {
+    expect(
+      identityChanged(saved({ macAddress: undefined }), saved({ macAddress: 'AA:BB:CC' }))
+    ).toBe(true);
+  });
+
+  it('ignores changes to non-identity fields (name, lastConnectedAt, isPaired)', () => {
+    const previous = saved({ name: 'TV', isPaired: false });
+    const updated = saved({ name: 'Living Room', isPaired: true });
+    expect(identityChanged(previous, updated)).toBe(false);
+  });
+});
+
+describe('findExistingForDraft', () => {
+  const list: SavedDevice[] = [
+    saved({ id: 'a', host: '10.0.0.1', macAddress: 'AA' }),
+    saved({ id: 'b', host: '10.0.0.2', castDeviceId: 'CAST-B' }),
+    saved({ id: 'c', host: '10.0.0.3', networkHostName: 'tv-c.local' }),
+    saved({ id: 'd', host: '10.0.0.4', deviceFingerprint: 'FP-D' }),
+    saved({ id: 'e', host: '10.0.0.5' }),
+  ];
+
+  it('matches by MAC when draft has one', () => {
+    expect(findExistingForDraft(draft({ macAddress: 'AA' }), list)?.id).toBe('a');
+  });
+
+  it('matches by castDeviceId when MAC is absent', () => {
+    expect(findExistingForDraft(draft({ castDeviceId: 'CAST-B' }), list)?.id).toBe('b');
+  });
+
+  it('matches by networkHostName when MAC + castDeviceId are absent', () => {
+    expect(findExistingForDraft(draft({ networkHostName: 'tv-c.local' }), list)?.id).toBe('c');
+  });
+
+  it('matches by fingerprint when the higher-priority fields are absent', () => {
+    expect(findExistingForDraft(draft({ deviceFingerprint: 'FP-D' }), list)?.id).toBe('d');
+  });
+
+  it('falls back to host', () => {
+    expect(findExistingForDraft(draft({ host: '10.0.0.5' }), list)?.id).toBe('e');
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(findExistingForDraft(draft({ host: '99.99.99.99' }), list)).toBeUndefined();
+  });
+
+  it('trims whitespace before matching', () => {
+    expect(findExistingForDraft(draft({ macAddress: '  AA  ' }), list)?.id).toBe('a');
+  });
+});
+
+describe('normalizeDraft', () => {
+  it('generates a fresh id for new devices using the injected generator', () => {
+    const result = normalizeDraft(draft(), undefined, () => 'GENERATED');
+    expect(result.id).toBe('GENERATED');
+    expect(result.isPaired).toBe(false);
+  });
+
+  it('preserves the existing id, isPaired, and lastConnectedAt', () => {
+    const existing = saved({ id: 'old-id', isPaired: true, lastConnectedAt: '2024-01-01' });
+    const result = normalizeDraft(draft(), existing, () => 'NEW-id');
+    expect(result.id).toBe('old-id');
+    expect(result.isPaired).toBe(true);
+    expect(result.lastConnectedAt).toBe('2024-01-01');
+  });
+
+  it('uses the draft name when non-empty', () => {
+    const result = normalizeDraft(draft({ name: 'Custom Name' }), undefined, () => 'id');
+    expect(result.name).toBe('Custom Name');
+  });
+
+  it('falls back to host when draft name is empty/whitespace', () => {
+    const result = normalizeDraft(
+      draft({ name: '   ', host: '192.168.1.5' }),
+      undefined,
+      () => 'id'
+    );
+    expect(result.name).toBe('192.168.1.5');
+  });
+
+  it('trims all identity strings', () => {
+    const result = normalizeDraft(
+      draft({ host: '  10.0.0.1  ', macAddress: '  AA  ', castDeviceId: '  CAST  ' }),
+      undefined,
+      () => 'id'
+    );
+    expect(result.host).toBe('10.0.0.1');
+    expect(result.macAddress).toBe('AA');
+    expect(result.castDeviceId).toBe('CAST');
+  });
+
+  it('prefers draft identity over existing where draft is set', () => {
+    const existing = saved({ macAddress: 'OLD' });
+    const result = normalizeDraft(draft({ macAddress: 'NEW' }), existing, () => 'id');
+    expect(result.macAddress).toBe('NEW');
+  });
+
+  it('falls back to existing identity where draft is silent', () => {
+    const existing = saved({ macAddress: 'OLD', castDeviceId: 'OLD-CAST' });
+    const result = normalizeDraft(draft(), existing, () => 'id');
+    expect(result.macAddress).toBe('OLD');
+    expect(result.castDeviceId).toBe('OLD-CAST');
+  });
+});

--- a/src/backend/devices/__tests__/deviceRepository.test.ts
+++ b/src/backend/devices/__tests__/deviceRepository.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { SavedDevice } from '../../../shared/types';
+import type { IFileSystem } from '../../core/fileSystem';
+import type { IPathProvider } from '../../core/pathProvider';
+import { DeviceRepository } from '../deviceRepository';
+
+const STORE_DIR = '/app-data';
+
+const paths: IPathProvider = {
+  getCertStateDir: () => STORE_DIR,
+  getAppDataPath: (...segments) => [STORE_DIR, ...segments].join('/'),
+};
+
+function makeFakeFs(
+  seed?: Record<string, string>
+): IFileSystem & { dump: () => Record<string, string> } {
+  const files = new Map<string, string>(Object.entries(seed ?? {}));
+  return {
+    readFile: (p, _enc) => {
+      const v = files.get(p);
+      if (v === undefined) {
+        return Promise.reject(Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' }));
+      }
+      return Promise.resolve(v);
+    },
+    writeFile: (p, contents, _enc) => {
+      files.set(p, contents);
+      return Promise.resolve();
+    },
+    mkdir: () => Promise.resolve(),
+    rm: (p, _opts) => {
+      files.delete(p);
+      return Promise.resolve();
+    },
+    rmRecursive: () => Promise.resolve(),
+    rename: () => Promise.resolve(),
+    exists: (p) => Promise.resolve(files.has(p)),
+    dump: () => Object.fromEntries(files),
+  };
+}
+
+const PAIRED_DEVICE: SavedDevice = {
+  id: 'd1',
+  isPaired: true,
+  name: 'Living Room TV',
+  host: '192.168.1.5',
+  adbPort: 5555,
+  pairingPort: 6467,
+};
+
+describe('DeviceRepository', () => {
+  let fs: ReturnType<typeof makeFakeFs>;
+  let repo: DeviceRepository;
+
+  beforeEach(() => {
+    fs = makeFakeFs();
+    repo = new DeviceRepository(fs, paths);
+  });
+
+  describe('storePath', () => {
+    it('returns devices.json under the app data dir by default', () => {
+      expect(repo.storePath()).toBe('/app-data/devices.json');
+    });
+
+    it('respects a custom file name', () => {
+      const custom = new DeviceRepository(fs, paths, 'my-devices.json');
+      expect(custom.storePath()).toBe('/app-data/my-devices.json');
+    });
+  });
+
+  describe('read', () => {
+    it('returns an empty list when the file does not exist (ENOENT)', async () => {
+      await expect(repo.read()).resolves.toEqual([]);
+    });
+
+    it('returns the devices array from a valid file', async () => {
+      fs = makeFakeFs({
+        '/app-data/devices.json': JSON.stringify({ devices: [PAIRED_DEVICE] }),
+      });
+      repo = new DeviceRepository(fs, paths);
+      const devices = await repo.read();
+      expect(devices).toEqual([PAIRED_DEVICE]);
+    });
+
+    it('returns an empty list when JSON has no `devices` key (legacy format)', async () => {
+      fs = makeFakeFs({ '/app-data/devices.json': JSON.stringify({}) });
+      repo = new DeviceRepository(fs, paths);
+      await expect(repo.read()).resolves.toEqual([]);
+    });
+
+    it('returns an empty list when `devices` is null', async () => {
+      fs = makeFakeFs({
+        '/app-data/devices.json': JSON.stringify({ devices: null }),
+      });
+      repo = new DeviceRepository(fs, paths);
+      await expect(repo.read()).resolves.toEqual([]);
+    });
+  });
+
+  describe('write', () => {
+    it('persists devices under the canonical key', async () => {
+      await repo.write([PAIRED_DEVICE]);
+      const raw = fs.dump()['/app-data/devices.json'];
+      expect(raw).toBeDefined();
+      expect(JSON.parse(raw ?? '{}')).toEqual({ devices: [PAIRED_DEVICE] });
+    });
+
+    it('round-trips through read', async () => {
+      await repo.write([PAIRED_DEVICE]);
+      await expect(repo.read()).resolves.toEqual([PAIRED_DEVICE]);
+    });
+
+    it('formats with 2-space indentation (matches the pre-extraction format)', async () => {
+      await repo.write([PAIRED_DEVICE]);
+      const raw = fs.dump()['/app-data/devices.json'] ?? '';
+      expect(raw).toContain('\n  "devices"');
+    });
+  });
+
+  describe('clear', () => {
+    it('removes the file', async () => {
+      await repo.write([PAIRED_DEVICE]);
+      await repo.clear();
+      expect(fs.dump()['/app-data/devices.json']).toBeUndefined();
+    });
+
+    it('is a no-op when the file is absent', async () => {
+      await expect(repo.clear()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/backend/devices/deviceRegistry.ts
+++ b/src/backend/devices/deviceRegistry.ts
@@ -1,0 +1,174 @@
+import type { DeviceDraft, DiscoveredDevice, SavedDevice } from '../../shared/types';
+
+/**
+ * Pure identity-matching utilities for devices. Extracted from the inline
+ * branches in `GoogleTvAdapter.runDeviceScan` and `GoogleTvAdapter.saveDevice`
+ * as part of PR-4.
+ *
+ * **Google TV non-regression gate #2** (after the cert store). These functions
+ * decide whether a freshly-discovered device on the network is "the same" as
+ * one the user already paired with — getting this wrong loses the pairing
+ * credential when an IP changes. The priority order is preserved exactly from
+ * the original code:
+ *
+ *     macAddress  >  castDeviceId  >  networkHostName  >  deviceFingerprint  >  host
+ *
+ * - `macAddress` is the most stable physical identifier; if both sides have one,
+ *   that's the only thing that matters.
+ * - `castDeviceId` is stable per-device across reboots but missing on some old TVs.
+ * - `networkHostName` is the mDNS-published name; stable per-device but only
+ *   if the user hasn't renamed the TV.
+ * - `deviceFingerprint` is a derived hash; we only use it if exactly one
+ *   discovered device has the same fingerprint (no ambiguity).
+ * - `host` is a pure IP-address fallback; used when nothing better is available.
+ */
+
+/**
+ * Match a saved device against the current scan results. Returns the matching
+ * discovered device, or `undefined` if no current device corresponds. The order
+ * of the checks below is the **contract**; do not reorder without updating the
+ * `deviceRegistry.test.ts` priority-matrix tests.
+ */
+export function matchSavedToDiscovered(
+  saved: SavedDevice,
+  discovered: readonly DiscoveredDevice[]
+): DiscoveredDevice | undefined {
+  const fingerprintMatches = saved.deviceFingerprint
+    ? discovered.filter((d) => d.deviceFingerprint === saved.deviceFingerprint)
+    : undefined;
+
+  return discovered.find((d) => {
+    if (saved.macAddress && d.macAddress) {
+      return d.macAddress === saved.macAddress;
+    }
+    if (saved.castDeviceId && d.castDeviceId) {
+      return d.castDeviceId === saved.castDeviceId;
+    }
+    if (saved.networkHostName && d.networkHostName) {
+      return d.networkHostName === saved.networkHostName;
+    }
+    if (fingerprintMatches?.length === 1) {
+      return d.id === fingerprintMatches[0]?.id;
+    }
+    return d.host === saved.host;
+  });
+}
+
+/**
+ * Merge identity fields from a scan match back into a saved device. Two cases:
+ *
+ *   - same host → backfill any newly-discovered metadata that we did not have
+ *     before (e.g. we now know the MAC), but preserve the host.
+ *   - different host → the TV moved to a new IP. Update host, backfill identity
+ *     metadata, and (caller is expected to migrate certs separately).
+ *
+ * `isPaired`, `lastConnectedAt`, custom name, and ports are preserved across
+ * both branches.
+ */
+export function mergeIdentity(saved: SavedDevice, match: DiscoveredDevice): SavedDevice {
+  if (match.host === saved.host) {
+    return {
+      ...saved,
+      macAddress: saved.macAddress ?? match.macAddress,
+      castDeviceId: saved.castDeviceId ?? match.castDeviceId,
+      networkHostName: saved.networkHostName ?? match.networkHostName,
+      deviceFingerprint: saved.deviceFingerprint ?? match.deviceFingerprint,
+    };
+  }
+
+  return {
+    ...saved,
+    host: match.host,
+    macAddress: saved.macAddress ?? match.macAddress,
+    castDeviceId: saved.castDeviceId ?? match.castDeviceId,
+    networkHostName: saved.networkHostName ?? match.networkHostName,
+    deviceFingerprint: saved.deviceFingerprint ?? match.deviceFingerprint,
+  };
+}
+
+/**
+ * True iff any identity-relevant field changed between the two devices. Used
+ * by callers to decide whether to persist + log + migrate certs after a scan.
+ */
+export function identityChanged(previous: SavedDevice, updated: SavedDevice): boolean {
+  return (
+    updated.host !== previous.host ||
+    updated.macAddress !== previous.macAddress ||
+    updated.castDeviceId !== previous.castDeviceId ||
+    updated.networkHostName !== previous.networkHostName ||
+    updated.deviceFingerprint !== previous.deviceFingerprint
+  );
+}
+
+/**
+ * Find an existing saved device that matches the given draft. Uses the same
+ * priority order as `matchSavedToDiscovered`, but on a single draft against
+ * the saved list (so the asymmetry is reversed). Used by "save device" flows
+ * to deduplicate.
+ *
+ * Returns `undefined` if no existing device matches — the caller should
+ * create a fresh one.
+ */
+export function findExistingForDraft(
+  draft: DeviceDraft,
+  savedList: readonly SavedDevice[]
+): SavedDevice | undefined {
+  const normalizedHost = draft.host.trim();
+  const normalizedMac = draft.macAddress?.trim();
+  const normalizedCastDeviceId = draft.castDeviceId?.trim();
+  const normalizedNetworkHostName = draft.networkHostName?.trim();
+  const normalizedDeviceFingerprint = draft.deviceFingerprint?.trim();
+
+  return savedList.find((device) => {
+    if (normalizedMac && device.macAddress) {
+      return device.macAddress === normalizedMac;
+    }
+    if (normalizedCastDeviceId && device.castDeviceId) {
+      return device.castDeviceId === normalizedCastDeviceId;
+    }
+    if (normalizedNetworkHostName && device.networkHostName) {
+      return device.networkHostName === normalizedNetworkHostName;
+    }
+    if (normalizedDeviceFingerprint && device.deviceFingerprint) {
+      return device.deviceFingerprint === normalizedDeviceFingerprint;
+    }
+    return device.host === normalizedHost;
+  });
+}
+
+/**
+ * Build a fully-normalised `SavedDevice` from a draft, preserving identity and
+ * state from `existing` where the draft is silent.
+ *
+ * - `id`            : preserved from existing, or freshly generated by the
+ *                     caller via `idGenerator()` (default: crypto.randomUUID).
+ * - `isPaired`      : preserved (defaults to `false` for new devices).
+ * - `name`          : draft wins if non-empty; otherwise we fall back to host.
+ * - identity fields : draft wins if set, existing as fallback.
+ * - `lastConnectedAt`: never modified here.
+ */
+export function normalizeDraft(
+  draft: DeviceDraft,
+  existing: SavedDevice | undefined,
+  idGenerator: () => string = () => globalThis.crypto.randomUUID()
+): SavedDevice {
+  const normalizedHost = draft.host.trim();
+  const normalizedMac = draft.macAddress?.trim();
+  const normalizedCastDeviceId = draft.castDeviceId?.trim();
+  const normalizedNetworkHostName = draft.networkHostName?.trim();
+  const normalizedDeviceFingerprint = draft.deviceFingerprint?.trim();
+
+  return {
+    id: existing?.id ?? idGenerator(),
+    isPaired: existing?.isPaired ?? false,
+    name: draft.name.trim() || normalizedHost,
+    host: normalizedHost,
+    adbPort: draft.adbPort,
+    pairingPort: draft.pairingPort,
+    macAddress: normalizedMac ?? existing?.macAddress,
+    castDeviceId: normalizedCastDeviceId ?? existing?.castDeviceId,
+    networkHostName: normalizedNetworkHostName ?? existing?.networkHostName,
+    deviceFingerprint: normalizedDeviceFingerprint ?? existing?.deviceFingerprint,
+    lastConnectedAt: existing?.lastConnectedAt,
+  };
+}

--- a/src/backend/devices/deviceRepository.ts
+++ b/src/backend/devices/deviceRepository.ts
@@ -1,0 +1,62 @@
+import path from 'node:path';
+
+import type { SavedDevice } from '../../shared/types';
+import type { IFileSystem } from '../core/fileSystem';
+import type { IPathProvider } from '../core/pathProvider';
+
+interface PersistedData {
+  devices?: SavedDevice[];
+}
+
+const DEFAULT_DATA: PersistedData = {
+  devices: [],
+};
+
+/**
+ * Persists the user's saved device list. Extracted from `src/main/device/store.ts`
+ * as part of PR-4. The original module-level helpers (`readDevices`, `writeDevices`,
+ * `clearDeviceStore`) become thin wrappers around an instance of this class so
+ * existing call sites keep working unchanged.
+ *
+ * The store is just `<userData>/devices.json`. Behaviour preserved exactly:
+ *
+ *   - missing file (ENOENT) → empty list, not an error
+ *   - JSON without a `devices` key → empty list (older format compatibility)
+ *   - `clear()` is best-effort; ENOENT is swallowed, other errors bubble up
+ */
+export class DeviceRepository {
+  constructor(
+    private readonly fs: IFileSystem,
+    private readonly paths: IPathProvider,
+    private readonly fileName = 'devices.json'
+  ) {}
+
+  /** Absolute path to the on-disk store. Exposed for debug logging / tests. */
+  storePath(): string {
+    return this.paths.getAppDataPath(this.fileName);
+  }
+
+  async read(): Promise<SavedDevice[]> {
+    const storePath = this.storePath();
+    if (!(await this.fs.exists(storePath))) {
+      return [];
+    }
+    const raw = await this.fs.readFile(storePath, 'utf8');
+    const parsed = JSON.parse(raw) as PersistedData;
+    return parsed.devices ?? [];
+  }
+
+  async write(devices: SavedDevice[]): Promise<void> {
+    const storePath = this.storePath();
+    await this.fs.mkdir(path.dirname(storePath), { recursive: true });
+    await this.fs.writeFile(
+      storePath,
+      JSON.stringify({ ...DEFAULT_DATA, devices }, null, 2),
+      'utf8'
+    );
+  }
+
+  async clear(): Promise<void> {
+    await this.fs.rm(this.storePath(), { force: true });
+  }
+}

--- a/src/main/device/store.ts
+++ b/src/main/device/store.ts
@@ -1,52 +1,31 @@
-import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import { app } from 'electron';
 
+import { createNodeFileSystem } from '../../backend/core/fileSystem';
+import { DeviceRepository } from '../../backend/devices/deviceRepository';
 import type { SavedDevice } from '../../shared/types';
 
-interface PersistedData {
-  devices?: SavedDevice[];
-}
-
-const DEFAULT_DATA: PersistedData = {
-  devices: [],
-};
-
-function getStorePath(): string {
-  return path.join(app.getPath('userData'), 'devices.json');
-}
+// Persistence is delegated to DeviceRepository (PR-4). The module-level
+// helpers below are preserved as thin wrappers so every existing call site
+// (GoogleTvAdapter, IPC handlers, etc.) keeps working unchanged.
+const repository = new DeviceRepository(createNodeFileSystem(), {
+  getCertStateDir: () => app.getPath('userData'),
+  getAppDataPath: (...segments) => path.join(app.getPath('userData'), ...segments),
+});
 
 export function getDeviceStorePath(): string {
-  return getStorePath();
+  return repository.storePath();
 }
 
 export async function readDevices(): Promise<SavedDevice[]> {
-  try {
-    const raw = await fs.readFile(getStorePath(), 'utf8');
-    const parsed = JSON.parse(raw) as PersistedData;
-    return parsed.devices ?? [];
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return [];
-    }
-
-    throw error;
-  }
+  return repository.read();
 }
 
 export async function writeDevices(devices: SavedDevice[]): Promise<void> {
-  const storePath = getStorePath();
-  await fs.mkdir(path.dirname(storePath), { recursive: true });
-  await fs.writeFile(storePath, JSON.stringify({ ...DEFAULT_DATA, devices }, null, 2), 'utf8');
+  await repository.write(devices);
 }
 
 export async function clearDeviceStore(): Promise<void> {
-  try {
-    await fs.rm(getStorePath(), { force: true });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-      throw error;
-    }
-  }
+  await repository.clear();
 }


### PR DESCRIPTION
## What

PR-4. Lifts device persistence and the identity-matching matrix out of `src/main/device/{store.ts,googleTvAdapter.ts}` into pure, unit-tested backend services.

## Files

- `src/backend/devices/deviceRepository.ts` (62 LOC) — `DeviceRepository` class. Wraps the JSON store behind `IFileSystem` + `IPathProvider`. Exposes `read / write / clear / storePath()`.
- `src/backend/devices/deviceRegistry.ts` (174 LOC) — five pure functions:
  - `matchSavedToDiscovered` — the priority ladder.
  - `mergeIdentity` — same-host backfill vs. IP-change merge.
  - `identityChanged` — change detection.
  - `findExistingForDraft` — same ladder for the save flow.
  - `normalizeDraft` — full normalisation with injectable id generator.
- `src/backend/devices/__tests__/deviceRepository.test.ts` — **11 tests**.
- `src/backend/devices/__tests__/deviceRegistry.test.ts` — **46 tests** organised as the contract priority matrix.
- `src/main/device/store.ts` — now a 30-line shim. Module-level `readDevices`/`writeDevices`/`clearDeviceStore`/`getDeviceStorePath` preserved exactly.

## Why this matters (Google TV non-regression gate #2)

`MAC > castDeviceId > networkHostName > fingerprint > host` is the priority ladder for deciding whether a freshly-discovered TV on the network is "the same" as one the user has already paired with. Getting any branch wrong loses the pairing credential on an IP change — historically the worst class of bug in this app.

The new contract tests pin every branch of that ladder, including:

- MAC dominates when both sides have one (host change is irrelevant)
- Fall-through past MAC if either side lacks it
- Fingerprint match **only** when exactly one discovered device has the same fingerprint (ambiguity → fall through)
- Pairing state preserved across an IP change
- Whitespace trimmed before matching in `findExistingForDraft`
- `normalizeDraft` prefers draft identity over existing, but falls back to existing when draft is silent
- `identityChanged` ignores name / `lastConnectedAt` / `isPaired`

## CI locally

- `npm test` — 127/127 pass (57 new)
- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run format:check` — clean
- `npm run build` — succeeds

## Risk

**Low.** The shim preserves `store.ts`'s public API exactly. The registry functions are byte-identical extractions from `GoogleTvAdapter` — the integration into the adapter itself is a deliberate no-op in this PR (saved for PR-5 once `AppFacade` lands, so this PR can be reviewed independently of the adapter rewrite).

## Stack

- Lands on top of current `main` (assumes PR #64 / PR #65 merged).
- Future PR-5 will replace `GoogleTvAdapter.runDeviceScan` / `saveDevice` to call the registry directly, deleting the inline duplication.
