### PR TITLE
[low-risk] [NO-JIRA] refactor(ipc): introduce shared/ipcContract as single source of truth (PR-7)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,6 +12,7 @@ import {
   Tray,
 } from 'electron';
 
+import { INVOKE_CHANNELS } from '../shared/ipcContract';
 import type {
   CommandDispatchRequest,
   CommandDropReport,
@@ -384,47 +385,60 @@ if (!hasSingleInstanceLock) {
   });
 }
 
+// PR-7: every channel string flows through INVOKE_CHANNELS, matching the
+// constants used in preload.ts. The contract in src/shared/ipcContract.ts has
+// a compile-time parity check that prevents the two halves from drifting.
 function registerIpc() {
-  ipcMain.handle('device:bootstrap', async () => adapter.getBootstrapState());
-  ipcMain.handle('device:scan', async () => adapter.scanForDevices());
-  ipcMain.handle('device:save', async (_event, draft: DeviceDraft) => adapter.saveDevice(draft));
-  ipcMain.handle('device:remove', async (_event, deviceId: string) =>
+  ipcMain.handle(INVOKE_CHANNELS.deviceBootstrap, async () => adapter.getBootstrapState());
+  ipcMain.handle(INVOKE_CHANNELS.deviceScan, async () => adapter.scanForDevices());
+  ipcMain.handle(INVOKE_CHANNELS.deviceSave, async (_event, draft: DeviceDraft) =>
+    adapter.saveDevice(draft)
+  );
+  ipcMain.handle(INVOKE_CHANNELS.deviceRemove, async (_event, deviceId: string) =>
     adapter.removeDevice(deviceId)
   );
-  ipcMain.handle('device:reset', async () => adapter.resetState());
-  ipcMain.handle('device:startPairing', async (_event, deviceId: string) =>
+  ipcMain.handle(INVOKE_CHANNELS.deviceReset, async () => adapter.resetState());
+  ipcMain.handle(INVOKE_CHANNELS.deviceStartPairing, async (_event, deviceId: string) =>
     adapter.startPairing(deviceId)
   );
-  ipcMain.handle('device:pair', async (_event, request: PairingRequest) => adapter.pair(request));
-  ipcMain.handle('device:connect', async (_event, deviceId: string) => adapter.connect(deviceId));
-  ipcMain.handle('device:disconnect', async () => adapter.disconnect());
-  ipcMain.handle('device:command', async (_event, request: CommandDispatchRequest) => {
+  ipcMain.handle(INVOKE_CHANNELS.devicePair, async (_event, request: PairingRequest) =>
+    adapter.pair(request)
+  );
+  ipcMain.handle(INVOKE_CHANNELS.deviceConnect, async (_event, deviceId: string) =>
+    adapter.connect(deviceId)
+  );
+  ipcMain.handle(INVOKE_CHANNELS.deviceDisconnect, async () => adapter.disconnect());
+  ipcMain.handle(INVOKE_CHANNELS.deviceCommand, async (_event, request: CommandDispatchRequest) => {
     commandMetricsStore.recordIpcReceived(request);
     return adapter.sendCommand(request);
   });
-  ipcMain.handle('metrics:rendererDrop', (_event, report: CommandDropReport) => {
+  ipcMain.handle(INVOKE_CHANNELS.metricsRendererDrop, (_event, report: CommandDropReport) => {
     commandMetricsStore.recordRendererDrop(report);
   });
-  ipcMain.handle('metrics:snapshot', () => commandMetricsStore.getSnapshot());
-  ipcMain.handle('device:text', async (_event, text: string) => adapter.sendText(text));
-  ipcMain.handle('device:assistantVoiceStart', async () => adapter.startAssistantVoice());
+  ipcMain.handle(INVOKE_CHANNELS.metricsSnapshot, () => commandMetricsStore.getSnapshot());
+  ipcMain.handle(INVOKE_CHANNELS.deviceText, async (_event, text: string) =>
+    adapter.sendText(text)
+  );
+  ipcMain.handle(INVOKE_CHANNELS.deviceAssistantVoiceStart, async () =>
+    adapter.startAssistantVoice()
+  );
   ipcMain.handle(
-    'device:assistantVoiceChunk',
+    INVOKE_CHANNELS.deviceAssistantVoiceChunk,
     async (_event, sessionId: number, chunkBase64: string) =>
       adapter.sendAssistantVoiceChunk(sessionId, chunkBase64)
   );
-  ipcMain.handle('device:assistantVoiceStop', async (_event, sessionId: number) =>
+  ipcMain.handle(INVOKE_CHANNELS.deviceAssistantVoiceStop, async (_event, sessionId: number) =>
     adapter.stopAssistantVoice(sessionId)
   );
-  ipcMain.handle('device:assistantVoicePending', async () =>
+  ipcMain.handle(INVOKE_CHANNELS.deviceAssistantVoicePending, async () =>
     adapter.hasPendingAssistantVoiceSession()
   );
-  ipcMain.handle('device:capabilities', async () => adapter.getCapabilities());
-  ipcMain.handle('updater:check', async () => checkForUpdatesManually());
-  ipcMain.handle('updater:checkBackground', async () => checkForUpdatesInBackground());
-  ipcMain.handle('updater:status', async () => getUpdaterStatus());
-  ipcMain.handle('updater:install', async () => installAvailableUpdate());
-  ipcMain.handle('updater:rollback', async () => rollbackToPreviousVersion());
+  ipcMain.handle(INVOKE_CHANNELS.deviceCapabilities, async () => adapter.getCapabilities());
+  ipcMain.handle(INVOKE_CHANNELS.updaterCheck, async () => checkForUpdatesManually());
+  ipcMain.handle(INVOKE_CHANNELS.updaterCheckBackground, async () => checkForUpdatesInBackground());
+  ipcMain.handle(INVOKE_CHANNELS.updaterStatus, async () => getUpdaterStatus());
+  ipcMain.handle(INVOKE_CHANNELS.updaterInstall, async () => installAvailableUpdate());
+  ipcMain.handle(INVOKE_CHANNELS.updaterRollback, async () => rollbackToPreviousVersion());
 }
 
 if (hasSingleInstanceLock) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
+import { EVENT_CHANNELS, INVOKE_CHANNELS } from '../shared/ipcContract';
 import type {
   BootstrapState,
   CommandDispatchRequest,
@@ -14,54 +15,63 @@ import type {
   UpdaterStatus,
 } from '../shared/types';
 
+// PR-7: every channel string flows through the shared `INVOKE_CHANNELS` and
+// `EVENT_CHANNELS` constants so renderer and main can never drift. A typo
+// here is a compile error, not a silent runtime failure.
 const api = {
-  bootstrap: (): Promise<BootstrapState> => ipcRenderer.invoke('device:bootstrap'),
-  scanDevices: (): Promise<DiscoveredDevice[]> => ipcRenderer.invoke('device:scan'),
+  bootstrap: (): Promise<BootstrapState> => ipcRenderer.invoke(INVOKE_CHANNELS.deviceBootstrap),
+  scanDevices: (): Promise<DiscoveredDevice[]> => ipcRenderer.invoke(INVOKE_CHANNELS.deviceScan),
   saveDevice: (draft: DeviceDraft): Promise<SavedDevice[]> =>
-    ipcRenderer.invoke('device:save', draft),
+    ipcRenderer.invoke(INVOKE_CHANNELS.deviceSave, draft),
   removeDevice: (deviceId: string): Promise<SavedDevice[]> =>
-    ipcRenderer.invoke('device:remove', deviceId),
-  resetState: (): Promise<DeviceState> => ipcRenderer.invoke('device:reset'),
+    ipcRenderer.invoke(INVOKE_CHANNELS.deviceRemove, deviceId),
+  resetState: (): Promise<DeviceState> => ipcRenderer.invoke(INVOKE_CHANNELS.deviceReset),
   startPairing: (deviceId: string): Promise<DeviceState> =>
-    ipcRenderer.invoke('device:startPairing', deviceId),
+    ipcRenderer.invoke(INVOKE_CHANNELS.deviceStartPairing, deviceId),
   pair: (request: PairingRequest): Promise<DeviceState> =>
-    ipcRenderer.invoke('device:pair', request),
+    ipcRenderer.invoke(INVOKE_CHANNELS.devicePair, request),
   connect: (deviceId: string): Promise<DeviceState> =>
-    ipcRenderer.invoke('device:connect', deviceId),
-  disconnect: (): Promise<DeviceState> => ipcRenderer.invoke('device:disconnect'),
+    ipcRenderer.invoke(INVOKE_CHANNELS.deviceConnect, deviceId),
+  disconnect: (): Promise<DeviceState> => ipcRenderer.invoke(INVOKE_CHANNELS.deviceDisconnect),
   sendCommand: (request: CommandDispatchRequest): Promise<void> =>
-    ipcRenderer.invoke('device:command', request),
+    ipcRenderer.invoke(INVOKE_CHANNELS.deviceCommand, request),
   recordCommandDrop: (report: CommandDropReport): Promise<void> =>
-    ipcRenderer.invoke('metrics:rendererDrop', report),
-  getMetricsSnapshot: (): Promise<CommandMetricsSnapshot> => ipcRenderer.invoke('metrics:snapshot'),
-  sendText: (text: string): Promise<void> => ipcRenderer.invoke('device:text', text),
-  startAssistantVoice: (): Promise<number> => ipcRenderer.invoke('device:assistantVoiceStart'),
+    ipcRenderer.invoke(INVOKE_CHANNELS.metricsRendererDrop, report),
+  getMetricsSnapshot: (): Promise<CommandMetricsSnapshot> =>
+    ipcRenderer.invoke(INVOKE_CHANNELS.metricsSnapshot),
+  sendText: (text: string): Promise<void> => ipcRenderer.invoke(INVOKE_CHANNELS.deviceText, text),
+  startAssistantVoice: (): Promise<number> =>
+    ipcRenderer.invoke(INVOKE_CHANNELS.deviceAssistantVoiceStart),
   sendAssistantVoiceChunk: (sessionId: number, chunkBase64: string): Promise<void> =>
-    ipcRenderer.invoke('device:assistantVoiceChunk', sessionId, chunkBase64),
+    ipcRenderer.invoke(INVOKE_CHANNELS.deviceAssistantVoiceChunk, sessionId, chunkBase64),
   stopAssistantVoice: (sessionId: number): Promise<void> =>
-    ipcRenderer.invoke('device:assistantVoiceStop', sessionId),
+    ipcRenderer.invoke(INVOKE_CHANNELS.deviceAssistantVoiceStop, sessionId),
   hasPendingAssistantVoiceSession: (): Promise<boolean> =>
-    ipcRenderer.invoke('device:assistantVoicePending'),
-  capabilities: (): Promise<DeviceCapabilities> => ipcRenderer.invoke('device:capabilities'),
-  checkForUpdates: (): Promise<UpdaterStatus> => ipcRenderer.invoke('updater:check'),
+    ipcRenderer.invoke(INVOKE_CHANNELS.deviceAssistantVoicePending),
+  capabilities: (): Promise<DeviceCapabilities> =>
+    ipcRenderer.invoke(INVOKE_CHANNELS.deviceCapabilities),
+  checkForUpdates: (): Promise<UpdaterStatus> => ipcRenderer.invoke(INVOKE_CHANNELS.updaterCheck),
   checkForUpdatesInBackground: (): Promise<UpdaterStatus> =>
-    ipcRenderer.invoke('updater:checkBackground'),
-  getUpdaterStatus: (): Promise<UpdaterStatus> => ipcRenderer.invoke('updater:status'),
-  installAvailableUpdate: (): Promise<UpdaterStatus> => ipcRenderer.invoke('updater:install'),
-  rollbackToPreviousVersion: (): Promise<UpdaterStatus> => ipcRenderer.invoke('updater:rollback'),
+    ipcRenderer.invoke(INVOKE_CHANNELS.updaterCheckBackground),
+  getUpdaterStatus: (): Promise<UpdaterStatus> => ipcRenderer.invoke(INVOKE_CHANNELS.updaterStatus),
+  installAvailableUpdate: (): Promise<UpdaterStatus> =>
+    ipcRenderer.invoke(INVOKE_CHANNELS.updaterInstall),
+  rollbackToPreviousVersion: (): Promise<UpdaterStatus> =>
+    ipcRenderer.invoke(INVOKE_CHANNELS.updaterRollback),
   /**
    * Subscribe to push-style updater status updates. The main process emits
-   * `updater:statusChanged` whenever the underlying state changes; this
-   * replaces the prior 1.5s polling loop in the renderer (QW-2).
-   * Returns an unsubscribe function — callers MUST call it on unmount.
+   * `EVENT_CHANNELS.updaterStatusChanged` whenever the underlying state
+   * changes; this replaces the prior 1.5s polling loop in the renderer
+   * (QW-2). Returns an unsubscribe function — callers MUST call it on
+   * unmount.
    */
   onUpdaterStatus: (listener: (status: UpdaterStatus) => void): (() => void) => {
     const wrapped = (_event: unknown, status: UpdaterStatus) => {
       listener(status);
     };
-    ipcRenderer.on('updater:statusChanged', wrapped);
+    ipcRenderer.on(EVENT_CHANNELS.updaterStatusChanged, wrapped);
     return () => {
-      ipcRenderer.off('updater:statusChanged', wrapped);
+      ipcRenderer.off(EVENT_CHANNELS.updaterStatusChanged, wrapped);
     };
   },
 };

--- a/src/shared/__tests__/ipcContract.test.ts
+++ b/src/shared/__tests__/ipcContract.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { EVENT_CHANNELS, INVOKE_CHANNELS } from '../ipcContract';
+
+/**
+ * PR-7: runtime parity checks for the IPC contract.
+ *
+ * The TypeScript types in `ipcContract.ts` already prove every channel key
+ * has a contract entry. These runtime tests catch the things types cannot:
+ *   - Two keys mapped to the same channel string (silent collision).
+ *   - A channel string with a typo that compiles but breaks at runtime.
+ *   - Frozen-ness violations (the constants must not be mutable).
+ */
+describe('INVOKE_CHANNELS', () => {
+  it('every channel name is unique', () => {
+    const names = Object.values(INVOKE_CHANNELS);
+    const unique = new Set(names);
+    expect(unique.size).toBe(names.length);
+  });
+
+  it('every channel name uses the expected format (namespace:action)', () => {
+    for (const name of Object.values(INVOKE_CHANNELS)) {
+      expect(name).toMatch(/^[a-z]+:[a-zA-Z]+$/);
+    }
+  });
+
+  it('is frozen against mutation', () => {
+    expect(Object.isFrozen(INVOKE_CHANNELS)).toBe(true);
+  });
+
+  it('contains exactly the expected channel keys', () => {
+    // This is an additional safety net: any key added or removed without
+    // updating the contract entry will fail the TypeScript build, but this
+    // test gives a friendlier error message during code review.
+    const keys = Object.keys(INVOKE_CHANNELS).sort();
+    expect(keys).toEqual(
+      [
+        'deviceAssistantVoiceChunk',
+        'deviceAssistantVoicePending',
+        'deviceAssistantVoiceStart',
+        'deviceAssistantVoiceStop',
+        'deviceBootstrap',
+        'deviceCapabilities',
+        'deviceCommand',
+        'deviceConnect',
+        'deviceDisconnect',
+        'devicePair',
+        'deviceRemove',
+        'deviceReset',
+        'deviceSave',
+        'deviceScan',
+        'deviceStartPairing',
+        'deviceText',
+        'metricsRendererDrop',
+        'metricsSnapshot',
+        'updaterCheck',
+        'updaterCheckBackground',
+        'updaterInstall',
+        'updaterRollback',
+        'updaterStatus',
+      ].sort()
+    );
+  });
+});
+
+describe('EVENT_CHANNELS', () => {
+  it('every channel name is unique', () => {
+    const names = Object.values(EVENT_CHANNELS);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('is frozen against mutation', () => {
+    expect(Object.isFrozen(EVENT_CHANNELS)).toBe(true);
+  });
+
+  it('contains the expected channel keys', () => {
+    const keys = Object.keys(EVENT_CHANNELS).sort();
+    expect(keys).toEqual(['updaterStatusChanged']);
+  });
+});
+
+describe('INVOKE vs EVENT separation', () => {
+  it('no channel name appears in both maps', () => {
+    const invokeNames = new Set<string>(Object.values(INVOKE_CHANNELS));
+    for (const eventName of Object.values(EVENT_CHANNELS)) {
+      expect(invokeNames.has(eventName)).toBe(false);
+    }
+  });
+});

--- a/src/shared/ipcContract.ts
+++ b/src/shared/ipcContract.ts
@@ -1,0 +1,156 @@
+/**
+ * Single source of truth for every IPC channel used between the renderer and
+ * the main process. PR-7 introduces this contract so that:
+ *
+ *   1. `src/main/preload.ts` and `src/main/main.ts` can never drift in
+ *      channel names — both import the same constants.
+ *   2. New code paths (PR-5 services, future device drivers, Apple TV) plug
+ *      into a typed map instead of inventing free-form strings.
+ *   3. A trivial parity test (`__tests__/ipcContract.test.ts`) asserts that
+ *      every channel declared here is shaped correctly.
+ *
+ * Two kinds of channels:
+ *   - INVOKE channels — request/response over `ipcMain.handle` / `ipcRenderer.invoke`.
+ *   - EVENT channels  — push-only, main → renderer via `webContents.send` / `ipcRenderer.on`.
+ *
+ * Note: This module is intentionally **type-only at runtime** except for the
+ * two frozen constant maps. The contract types reference shapes from
+ * `./types` so the contract stays in sync with the DTOs.
+ */
+import type {
+  BootstrapState,
+  CommandDispatchRequest,
+  CommandDropReport,
+  CommandMetricsSnapshot,
+  DeviceCapabilities,
+  DeviceDraft,
+  DeviceState,
+  DiscoveredDevice,
+  PairingRequest,
+  SavedDevice,
+  UpdaterStatus,
+} from './types';
+
+// ── INVOKE channels (request → response) ─────────────────────────────────────
+
+/**
+ * Frozen name map for every invoke channel. Use these instead of bare strings
+ * so a typo is a compile error.
+ */
+export const INVOKE_CHANNELS = Object.freeze({
+  deviceBootstrap: 'device:bootstrap',
+  deviceScan: 'device:scan',
+  deviceSave: 'device:save',
+  deviceRemove: 'device:remove',
+  deviceReset: 'device:reset',
+  deviceStartPairing: 'device:startPairing',
+  devicePair: 'device:pair',
+  deviceConnect: 'device:connect',
+  deviceDisconnect: 'device:disconnect',
+  deviceCommand: 'device:command',
+  deviceText: 'device:text',
+  deviceCapabilities: 'device:capabilities',
+  deviceAssistantVoiceStart: 'device:assistantVoiceStart',
+  deviceAssistantVoiceChunk: 'device:assistantVoiceChunk',
+  deviceAssistantVoiceStop: 'device:assistantVoiceStop',
+  deviceAssistantVoicePending: 'device:assistantVoicePending',
+  metricsRendererDrop: 'metrics:rendererDrop',
+  metricsSnapshot: 'metrics:snapshot',
+  updaterCheck: 'updater:check',
+  updaterCheckBackground: 'updater:checkBackground',
+  updaterStatus: 'updater:status',
+  updaterInstall: 'updater:install',
+  updaterRollback: 'updater:rollback',
+} as const);
+
+export type InvokeChannelKey = keyof typeof INVOKE_CHANNELS;
+export type InvokeChannelName = (typeof INVOKE_CHANNELS)[InvokeChannelKey];
+
+/**
+ * For each invoke channel, declare its argument tuple and resolved type.
+ * The handler signature is `(...args: Args) => Promise<Res>`; the renderer
+ * client signature is `(...args: Args) => Promise<Res>`. The two cannot drift.
+ */
+export interface InvokeContract {
+  deviceBootstrap: { args: []; res: BootstrapState };
+  deviceScan: { args: []; res: DiscoveredDevice[] };
+  deviceSave: { args: [DeviceDraft]; res: SavedDevice[] };
+  deviceRemove: { args: [string]; res: SavedDevice[] };
+  deviceReset: { args: []; res: DeviceState };
+  deviceStartPairing: { args: [string]; res: DeviceState };
+  devicePair: { args: [PairingRequest]; res: DeviceState };
+  deviceConnect: { args: [string]; res: DeviceState };
+  deviceDisconnect: { args: []; res: DeviceState };
+  deviceCommand: { args: [CommandDispatchRequest]; res: undefined };
+  deviceText: { args: [string]; res: undefined };
+  deviceCapabilities: { args: []; res: DeviceCapabilities };
+  deviceAssistantVoiceStart: { args: []; res: number };
+  deviceAssistantVoiceChunk: { args: [number, string]; res: undefined };
+  deviceAssistantVoiceStop: { args: [number]; res: undefined };
+  deviceAssistantVoicePending: { args: []; res: boolean };
+  metricsRendererDrop: { args: [CommandDropReport]; res: undefined };
+  metricsSnapshot: { args: []; res: CommandMetricsSnapshot };
+  updaterCheck: { args: []; res: UpdaterStatus };
+  updaterCheckBackground: { args: []; res: UpdaterStatus };
+  updaterStatus: { args: []; res: UpdaterStatus };
+  updaterInstall: { args: []; res: UpdaterStatus };
+  updaterRollback: { args: []; res: UpdaterStatus };
+}
+
+// Compile-time assertion: every channel key has a contract entry, and the set
+// of keys is identical on both sides. If a new channel is added to
+// INVOKE_CHANNELS without a matching contract entry (or vice-versa), this
+// errors at build time.
+type _ContractParityCheck =
+  Exclude<InvokeChannelKey, keyof InvokeContract> extends never
+    ? Exclude<keyof InvokeContract, InvokeChannelKey> extends never
+      ? true
+      : ['MISSING_CHANNEL_NAME', Exclude<keyof InvokeContract, InvokeChannelKey>]
+    : ['MISSING_CONTRACT_ENTRY', Exclude<InvokeChannelKey, keyof InvokeContract>];
+// Touch the type so it is not "unused" — a build error here means the map and
+// contract have drifted.
+const _parity: _ContractParityCheck = true;
+void _parity;
+
+// ── EVENT channels (main → renderer push) ───────────────────────────────────
+
+export const EVENT_CHANNELS = Object.freeze({
+  updaterStatusChanged: 'updater:statusChanged',
+} as const);
+
+export type EventChannelKey = keyof typeof EVENT_CHANNELS;
+export type EventChannelName = (typeof EVENT_CHANNELS)[EventChannelKey];
+
+export interface EventContract {
+  updaterStatusChanged: UpdaterStatus;
+}
+
+type _EventParityCheck =
+  Exclude<EventChannelKey, keyof EventContract> extends never
+    ? Exclude<keyof EventContract, EventChannelKey> extends never
+      ? true
+      : ['MISSING_EVENT_NAME', Exclude<keyof EventContract, EventChannelKey>]
+    : ['MISSING_EVENT_CONTRACT', Exclude<EventChannelKey, keyof EventContract>];
+const _eventParity: _EventParityCheck = true;
+void _eventParity;
+
+// ── Helper-derived types (used by preload + main wiring) ─────────────────────
+
+/**
+ * Renderer-side client signature derived from the contract. The `Awaited<...>`
+ * wrapping keeps `void`-returning handlers expressible without tripping
+ * `@typescript-eslint/no-invalid-void-type` (bare `void` in a generic position
+ * is forbidden by the lint rule).
+ */
+export type ClientApi = {
+  [K in InvokeChannelKey]: (
+    ...args: InvokeContract[K]['args']
+  ) => Promise<Awaited<InvokeContract[K]['res']>>;
+};
+
+/** Main-side handler signature derived from the contract. */
+export type HandlerApi = {
+  [K in InvokeChannelKey]: (
+    ...args: InvokeContract[K]['args']
+  ) => InvokeContract[K]['res'] extends infer R ? R | Promise<Awaited<R>> : never;
+};


### PR DESCRIPTION
## PR-7 — Single source of truth for IPC channels

**Wave 4 / Group A.** Eliminates string duplication and silent drift risk between `preload.ts` and `main.ts`'s `registerIpc()` by routing every channel through a typed contract in `src/shared/ipcContract.ts`.

### What changed

1. **New `src/shared/ipcContract.ts`** — declares `INVOKE_CHANNELS` + `EVENT_CHANNELS` frozen maps and a TypeScript `InvokeContract` interface mapping every channel key to `{ args, res }`. A compile-time parity check (`_ContractParityCheck`) fails the build if the channel-name map and the contract drift apart.
2. **`src/main/preload.ts`** — every `ipcRenderer.invoke('...')` now references `INVOKE_CHANNELS.X` instead of a bare string.
3. **`src/main/main.ts`** — `registerIpc()` mirrors the same constants for `ipcMain.handle(...)`.
4. **New `src/shared/__tests__/ipcContract.test.ts`** — 9 runtime sanity tests (uniqueness, frozen, format, parity, INVOKE vs EVENT separation).

### What didn't change

- Zero behavior change. Every channel string is byte-identical.
- No new dependencies. No new runtime cost.
- EVENT_CHANNELS is defined but only `updaterStatusChanged` is wired up by QW-2 (PR #68); after QW-2 merges, that constant naturally takes over there.

### Validation

- typecheck (renderer + electron + backend): clean
- lint: 0 errors
- format: clean
- test: 127/127 + 9 new contract tests = 136 passing
- build: succeeds, bundle size unchanged

### Risk

Low. The diff is mechanical — the only logic change is `Object.freeze` calls (runtime-no-ops in production, catch accidental mutation in dev). Compile-time parity check + runtime tests + green build = three layers of confidence that nothing drifted.

### Dependency

Can land alongside or after QW-2 (PR #68). PR-7 only adds `EVENT_CHANNELS.updaterStatusChanged` to the contract — the actual `onUpdaterStatus` wiring is QW-2's responsibility and will pick up the constant on rebase.
