### PR TITLE
[low-risk] [NO-JIRA] refactor(shared): typed DesktopApi derived from IPC contract (PR-5c)

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
+import type { DesktopApi } from '../shared/desktopApi';
 import { EVENT_CHANNELS, INVOKE_CHANNELS } from '../shared/ipcContract';
 import type {
   BootstrapState,
@@ -76,6 +77,14 @@ const api = {
   },
 };
 
-contextBridge.exposeInMainWorld('gtvRemote', api);
+// PR-5c: assert at compile time that the preload `api` matches the
+// renderer-facing `DesktopApi` surface derived from the IPC contract. If a
+// channel is added to `INVOKE_CHANNELS` without a corresponding preload
+// method (or the method's signature drifts), this fails the build.
+const typedApi: DesktopApi = api;
 
-export type DesktopApi = typeof api;
+contextBridge.exposeInMainWorld('gtvRemote', typedApi);
+
+// Re-export DesktopApi as a courtesy for any code that still imports from
+// `./preload`; the canonical location is now `src/shared/desktopApi.ts`.
+export type { DesktopApi } from '../shared/desktopApi';

--- a/src/renderer/vite-env.d.ts
+++ b/src/renderer/vite-env.d.ts
@@ -1,6 +1,10 @@
 /// <reference types="vite/client" />
 
-import type { DesktopApi } from '../main/preload';
+// PR-5c: renderer no longer reaches into `../main/preload` for its type
+// surface — `DesktopApi` lives in `src/shared/desktopApi.ts` and is derived
+// from the typed IPC contract. This removes a long-standing renderer →
+// main layering violation.
+import type { DesktopApi } from '../shared/desktopApi';
 
 declare global {
   interface Window {

--- a/src/shared/desktopApi.ts
+++ b/src/shared/desktopApi.ts
@@ -1,0 +1,87 @@
+/**
+ * `DesktopApi` is the typed surface that the renderer sees on
+ * `window.gtvRemote`. It is derived from the IPC contract in `ipcContract.ts`
+ * so the renderer and preload can never drift on shape.
+ *
+ * Two parts:
+ *
+ *   1. The INVOKE half: every key in `INVOKE_CHANNELS` has a corresponding
+ *      method, generated from `ClientApi`. But the renderer-facing API uses
+ *      friendlier names (e.g. `bootstrap` instead of `deviceBootstrap`).
+ *      We keep the friendly-name mapping in `InvokeMethodMap` below so the
+ *      preload implementation and the renderer's call sites stay readable.
+ *
+ *   2. The EVENT half: `onXxx(listener): () => void` subscription methods,
+ *      one per `EVENT_CHANNELS` entry. These are not covered by `ClientApi`
+ *      because they are not request/response — they are push-only.
+ *
+ * Defining the type here (in `shared/`) instead of in `main/preload.ts`
+ * removes the cross-layer import from the renderer (`vite-env.d.ts`
+ * previously imported from `'../main/preload'`, which is a layering
+ * violation that ESLint will eventually forbid).
+ */
+import type { ClientApi, InvokeChannelKey } from './ipcContract';
+import type { UpdaterStatus } from './types';
+
+/**
+ * Friendly renderer-facing method names mapped onto the contract keys. The
+ * preload layer constructs an object whose keys are these friendly names and
+ * whose method bodies invoke the corresponding `INVOKE_CHANNELS[Key]`.
+ *
+ * Adding a new IPC channel: add the friendly name → contract key here, and
+ * the type system forces preload and the renderer to follow.
+ */
+export interface InvokeMethodMap {
+  bootstrap: 'deviceBootstrap';
+  scanDevices: 'deviceScan';
+  saveDevice: 'deviceSave';
+  removeDevice: 'deviceRemove';
+  resetState: 'deviceReset';
+  startPairing: 'deviceStartPairing';
+  pair: 'devicePair';
+  connect: 'deviceConnect';
+  disconnect: 'deviceDisconnect';
+  sendCommand: 'deviceCommand';
+  recordCommandDrop: 'metricsRendererDrop';
+  getMetricsSnapshot: 'metricsSnapshot';
+  sendText: 'deviceText';
+  startAssistantVoice: 'deviceAssistantVoiceStart';
+  sendAssistantVoiceChunk: 'deviceAssistantVoiceChunk';
+  stopAssistantVoice: 'deviceAssistantVoiceStop';
+  hasPendingAssistantVoiceSession: 'deviceAssistantVoicePending';
+  capabilities: 'deviceCapabilities';
+  checkForUpdates: 'updaterCheck';
+  checkForUpdatesInBackground: 'updaterCheckBackground';
+  getUpdaterStatus: 'updaterStatus';
+  installAvailableUpdate: 'updaterInstall';
+  rollbackToPreviousVersion: 'updaterRollback';
+}
+
+// Compile-time check: the friendly map covers every contract key exactly once.
+type _InvokeMapKeys = InvokeMethodMap[keyof InvokeMethodMap];
+type _MissingFriendly = Exclude<InvokeChannelKey, _InvokeMapKeys>;
+type _ExtraFriendly = Exclude<_InvokeMapKeys, InvokeChannelKey>;
+type _InvokeMapParity = _MissingFriendly extends never
+  ? _ExtraFriendly extends never
+    ? true
+    : ['EXTRA_FRIENDLY_NAME', _ExtraFriendly]
+  : ['MISSING_FRIENDLY_NAME_FOR', _MissingFriendly];
+const _invokeMapParity: _InvokeMapParity = true;
+void _invokeMapParity;
+
+/** Renderer-side typed surface for the INVOKE half. */
+export type DesktopInvokeApi = {
+  [Friendly in keyof InvokeMethodMap]: ClientApi[InvokeMethodMap[Friendly]];
+};
+
+/** Renderer-side typed surface for the EVENT (push) half. */
+export interface DesktopEventApi {
+  /**
+   * Subscribe to updater status updates. Returns an unsubscribe function;
+   * callers MUST call it on unmount.
+   */
+  onUpdaterStatus(listener: (status: UpdaterStatus) => void): () => void;
+}
+
+/** The full `window.gtvRemote` surface. */
+export type DesktopApi = DesktopInvokeApi & DesktopEventApi;

--- a/src/shared/ipcContract.ts
+++ b/src/shared/ipcContract.ts
@@ -137,20 +137,27 @@ void _eventParity;
 // ── Helper-derived types (used by preload + main wiring) ─────────────────────
 
 /**
- * Renderer-side client signature derived from the contract. The `Awaited<...>`
- * wrapping keeps `void`-returning handlers expressible without tripping
- * `@typescript-eslint/no-invalid-void-type` (bare `void` in a generic position
- * is forbidden by the lint rule).
+ * Internal helper that maps the contract's `undefined` "no result" marker to
+ * `void` at the function-signature level. Promises of `void` and promises of
+ * `undefined` are not assignment-compatible in strict mode (assigning
+ * `Promise<void>` to `Promise<undefined>` fails), and the renderer's call
+ * sites already use `Promise<void>` for the no-result handlers, so the
+ * contract internally uses `undefined` (which satisfies the no-invalid-void
+ * lint rule) and the derived types surface `void`.
  */
+type ResultOf<K extends InvokeChannelKey> = InvokeContract[K]['res'] extends undefined
+  ? // eslint-disable-next-line @typescript-eslint/no-invalid-void-type -- deliberate; see ResultOf docblock above
+    void
+  : InvokeContract[K]['res'];
+
+/** Renderer-side client signature derived from the contract. */
 export type ClientApi = {
-  [K in InvokeChannelKey]: (
-    ...args: InvokeContract[K]['args']
-  ) => Promise<Awaited<InvokeContract[K]['res']>>;
+  [K in InvokeChannelKey]: (...args: InvokeContract[K]['args']) => Promise<ResultOf<K>>;
 };
 
 /** Main-side handler signature derived from the contract. */
 export type HandlerApi = {
   [K in InvokeChannelKey]: (
     ...args: InvokeContract[K]['args']
-  ) => InvokeContract[K]['res'] extends infer R ? R | Promise<Awaited<R>> : never;
+  ) => ResultOf<K> | Promise<ResultOf<K>>;
 };


### PR DESCRIPTION
## PR-5c — Typed `DesktopApi` derived from the IPC contract

**Wave 5 / Group A** (replaces the originally-planned QW-5 with the same goals).

### Why

Before this change, `src/renderer/vite-env.d.ts` imported `DesktopApi` from `../main/preload`. That's a renderer→main layering violation: the renderer reaches into the main process for its type surface.

### What changed

1. **New `src/shared/desktopApi.ts`** — the canonical `DesktopApi` type. Derived from `ClientApi` (from PR-7's `InvokeContract`) plus a friendly-name map (`InvokeMethodMap`) that turns contract keys (`deviceBootstrap`) into renderer-facing method names (`bootstrap`). A compile-time parity check fails the build if the friendly map and the contract drift.
2. **`src/main/preload.ts`** — adds `const typedApi: DesktopApi = api` before exposeInMainWorld. If preload drifts from the contract, the assignment fails to compile.
3. **`src/renderer/vite-env.d.ts`** — now imports `DesktopApi` from `../shared/desktopApi`. Renderer never reaches into main.
4. **`src/shared/ipcContract.ts`** — `ClientApi` / `HandlerApi` now route `undefined` results through a `ResultOf<K>` helper that maps `undefined → void` so preload's `Promise<void>` annotations are compatible with the contract's `Promise<undefined>` encoding.

### Validation

- typecheck (renderer + electron + backend): clean
- lint: 0 errors
- format: clean
- test: 127/127 passing
- build: succeeds

### Risk

Very low. Pure type plumbing. The compile-time assertion immediately surfaced one real bug from PR-7 (`Promise<void>` vs `Promise<undefined>`) which is also fixed in this PR.
