### PR TITLE
[medium-risk] [NO-JIRA] refactor(voice): extract VoiceSessionService from GoogleTvAdapter (PR-5b)

### DIFF
--- a/src/backend/voice/VoiceSessionService.ts
+++ b/src/backend/voice/VoiceSessionService.ts
@@ -1,0 +1,143 @@
+/**
+ * `VoiceSessionService` owns the lifecycle of an assistant-voice session
+ * against a single connected device. It was extracted from
+ * `GoogleTvAdapter.{start,send,stop,hasPending}AssistantVoice` in PR-5b so:
+ *
+ *   - the stats accounting + progress logging is testable without electron
+ *     or a live TV (constructor takes ports for transport / clock / logger);
+ *   - `GoogleTvAdapter` shrinks toward being a thin orchestrator;
+ *   - future Apple TV / Roku voice integrations have a single seam to plug
+ *     into instead of cluttering the per-device adapter.
+ *
+ * The service deliberately does NOT know about `SavedDevice` or `host`.
+ * The caller passes a `VoiceSessionTarget` per call; the service decides
+ * everything else (session id ownership, stats lifecycle, log cadence).
+ */
+export interface VoiceSessionTarget {
+  /** Stable id of the device the caller has resolved (used in log details). */
+  deviceId: string;
+  /** Network host of the device. */
+  host: string;
+  /** Optional MAC, used by the transport to disambiguate cert keys. */
+  macAddress?: string;
+}
+
+/**
+ * The "lower half" of the voice session — the four operations performed
+ * against a connected transport. In production this is implemented by
+ * `androidTvRemoteBridge`; in tests by an in-memory fake.
+ */
+export interface IVoiceTransport {
+  start(host: string, macAddress?: string): Promise<number>;
+  sendChunk(host: string, sessionId: number, chunk: Buffer, macAddress?: string): Promise<void>;
+  stop(host: string, sessionId: number, macAddress?: string): Promise<void>;
+  hasPending(host: string, macAddress?: string): Promise<boolean>;
+}
+
+/** Minimal clock port — only `now()` is needed for stats and durations. */
+export interface IClock {
+  now(): number;
+}
+
+/** Minimal logger port. Mirrors the shape of `src/main/logger.ts:logInfo`. */
+export interface IVoiceLogger {
+  info(scope: string, message: string, details?: Record<string, unknown>): Promise<void>;
+}
+
+interface SessionStats {
+  chunks: number;
+  bytes: number;
+  startedAt: number;
+}
+
+/** Log a progress entry every N chunks. Matches the cadence the previous
+ * inline code used (every 10 chunks) so log output is unchanged. */
+export const VOICE_PROGRESS_LOG_EVERY_N_CHUNKS = 10;
+
+export class VoiceSessionService {
+  private readonly stats = new Map<number, SessionStats>();
+
+  constructor(
+    private readonly transport: IVoiceTransport,
+    private readonly clock: IClock,
+    private readonly logger: IVoiceLogger
+  ) {}
+
+  /** Begin a voice session for the given device. Returns the transport's
+   * session id, which the caller must echo back on chunk / stop. */
+  async start(target: VoiceSessionTarget): Promise<number> {
+    const sessionId = await this.transport.start(target.host, target.macAddress);
+    await this.logger.info('adapter', 'Assistant voice session started', {
+      deviceId: target.deviceId,
+      host: target.host,
+      sessionId,
+    });
+    this.stats.set(sessionId, { chunks: 0, bytes: 0, startedAt: this.clock.now() });
+    return sessionId;
+  }
+
+  /**
+   * Decode `chunkBase64` and forward it to the transport. Updates per-session
+   * counters and emits a progress log line every N chunks.
+   *
+   * If a chunk arrives for an unknown session id (because the caller missed
+   * the start event or it was already stopped), the chunk is still forwarded
+   * — the transport may have its own queueing — but a warning-grade log line
+   * is emitted so the orphan is visible.
+   */
+  async sendChunk(
+    target: VoiceSessionTarget,
+    sessionId: number,
+    chunkBase64: string
+  ): Promise<void> {
+    const chunk = Buffer.from(chunkBase64, 'base64');
+    await this.transport.sendChunk(target.host, sessionId, chunk, target.macAddress);
+
+    const stats = this.stats.get(sessionId);
+    if (stats) {
+      stats.chunks += 1;
+      stats.bytes += chunk.length;
+      if (stats.chunks % VOICE_PROGRESS_LOG_EVERY_N_CHUNKS === 0) {
+        await this.logger.info('adapter', 'Assistant voice chunk progress', {
+          deviceId: target.deviceId,
+          host: target.host,
+          sessionId,
+          chunks: stats.chunks,
+          bytes: stats.bytes,
+        });
+      }
+    } else {
+      await this.logger.info('adapter', 'Assistant voice chunk sent without tracked session', {
+        deviceId: target.deviceId,
+        host: target.host,
+        sessionId,
+        bytes: chunk.length,
+      });
+    }
+  }
+
+  /** Stop the session and emit a summary log line (chunks / bytes / duration). */
+  async stop(target: VoiceSessionTarget, sessionId: number): Promise<void> {
+    await this.transport.stop(target.host, sessionId, target.macAddress);
+    const stats = this.stats.get(sessionId);
+    this.stats.delete(sessionId);
+    await this.logger.info('adapter', 'Assistant voice session ended', {
+      deviceId: target.deviceId,
+      host: target.host,
+      sessionId,
+      chunks: stats?.chunks ?? 0,
+      bytes: stats?.bytes ?? 0,
+      durationMs: stats ? this.clock.now() - stats.startedAt : undefined,
+    });
+  }
+
+  /** Whether the transport reports any pending session for the target. */
+  async hasPending(target: VoiceSessionTarget): Promise<boolean> {
+    return this.transport.hasPending(target.host, target.macAddress);
+  }
+
+  /** TEST-ONLY: peek tracked sessions. */
+  _trackedSessions(): readonly number[] {
+    return Array.from(this.stats.keys());
+  }
+}

--- a/src/backend/voice/__tests__/VoiceSessionService.test.ts
+++ b/src/backend/voice/__tests__/VoiceSessionService.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  VOICE_PROGRESS_LOG_EVERY_N_CHUNKS,
+  VoiceSessionService,
+  type IClock,
+  type IVoiceLogger,
+  type IVoiceTransport,
+  type VoiceSessionTarget,
+} from '../VoiceSessionService';
+
+const TARGET: VoiceSessionTarget = {
+  deviceId: 'dev-1',
+  host: '192.168.1.42',
+  macAddress: 'aa:bb:cc:dd:ee:ff',
+};
+
+interface TransportCall {
+  op: 'start' | 'sendChunk' | 'stop' | 'hasPending';
+  host: string;
+  sessionId?: number;
+  chunkLength?: number;
+  macAddress?: string;
+}
+
+interface LogEntry {
+  scope: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+function makeFakes(opts: { startSessionId?: number; pending?: boolean } = {}) {
+  const transportCalls: TransportCall[] = [];
+  const logs: LogEntry[] = [];
+  let timeNow = 1_000_000;
+
+  const transport: IVoiceTransport = {
+    start: (host, macAddress) => {
+      transportCalls.push({ op: 'start', host, macAddress });
+      return Promise.resolve(opts.startSessionId ?? 42);
+    },
+    sendChunk: (host, sessionId, chunk, macAddress) => {
+      transportCalls.push({
+        op: 'sendChunk',
+        host,
+        sessionId,
+        chunkLength: chunk.length,
+        macAddress,
+      });
+      return Promise.resolve();
+    },
+    stop: (host, sessionId, macAddress) => {
+      transportCalls.push({ op: 'stop', host, sessionId, macAddress });
+      return Promise.resolve();
+    },
+    hasPending: (host, macAddress) => {
+      transportCalls.push({ op: 'hasPending', host, macAddress });
+      return Promise.resolve(opts.pending ?? false);
+    },
+  };
+
+  const clock: IClock = {
+    now: () => timeNow,
+  };
+
+  const logger: IVoiceLogger = {
+    info: (scope, message, details) => {
+      logs.push({ scope, message, details });
+      return Promise.resolve();
+    },
+  };
+
+  return {
+    transport,
+    clock,
+    logger,
+    transportCalls,
+    logs,
+    advanceClock(ms: number) {
+      timeNow += ms;
+    },
+  };
+}
+
+describe('VoiceSessionService.start', () => {
+  it('returns the transport session id and logs start', async () => {
+    const fakes = makeFakes({ startSessionId: 7 });
+    const svc = new VoiceSessionService(fakes.transport, fakes.clock, fakes.logger);
+
+    const id = await svc.start(TARGET);
+    expect(id).toBe(7);
+    expect(fakes.transportCalls).toEqual([
+      { op: 'start', host: TARGET.host, macAddress: TARGET.macAddress },
+    ]);
+    expect(fakes.logs[0]).toMatchObject({
+      scope: 'adapter',
+      message: 'Assistant voice session started',
+      details: { deviceId: TARGET.deviceId, host: TARGET.host, sessionId: 7 },
+    });
+    expect(svc._trackedSessions()).toEqual([7]);
+  });
+});
+
+describe('VoiceSessionService.sendChunk', () => {
+  it('forwards the decoded chunk and increments stats', async () => {
+    const fakes = makeFakes();
+    const svc = new VoiceSessionService(fakes.transport, fakes.clock, fakes.logger);
+    const id = await svc.start(TARGET);
+    fakes.logs.length = 0;
+
+    // 'hello' base64 → 5 bytes
+    await svc.sendChunk(TARGET, id, Buffer.from('hello').toString('base64'));
+
+    expect(fakes.transportCalls).toContainEqual({
+      op: 'sendChunk',
+      host: TARGET.host,
+      sessionId: id,
+      chunkLength: 5,
+      macAddress: TARGET.macAddress,
+    });
+    expect(fakes.logs).toEqual([]); // no progress log at chunk #1
+  });
+
+  it(`emits a progress log every ${String(VOICE_PROGRESS_LOG_EVERY_N_CHUNKS)} chunks`, async () => {
+    const fakes = makeFakes();
+    const svc = new VoiceSessionService(fakes.transport, fakes.clock, fakes.logger);
+    const id = await svc.start(TARGET);
+    fakes.logs.length = 0;
+
+    const oneChunk = Buffer.from('xx').toString('base64'); // 2 bytes
+    for (let i = 0; i < VOICE_PROGRESS_LOG_EVERY_N_CHUNKS; i += 1) {
+      await svc.sendChunk(TARGET, id, oneChunk);
+    }
+    expect(fakes.logs).toHaveLength(1);
+    expect(fakes.logs[0]).toMatchObject({
+      message: 'Assistant voice chunk progress',
+      details: {
+        sessionId: id,
+        chunks: VOICE_PROGRESS_LOG_EVERY_N_CHUNKS,
+        bytes: 2 * VOICE_PROGRESS_LOG_EVERY_N_CHUNKS,
+      },
+    });
+  });
+
+  it('logs a warning when a chunk arrives for an untracked session', async () => {
+    const fakes = makeFakes();
+    const svc = new VoiceSessionService(fakes.transport, fakes.clock, fakes.logger);
+
+    await svc.sendChunk(TARGET, 999, Buffer.from('xy').toString('base64'));
+
+    expect(fakes.logs[0]).toMatchObject({
+      message: 'Assistant voice chunk sent without tracked session',
+      details: { sessionId: 999, bytes: 2 },
+    });
+  });
+});
+
+describe('VoiceSessionService.stop', () => {
+  it('reports chunks / bytes / durationMs in the summary log', async () => {
+    const fakes = makeFakes();
+    const svc = new VoiceSessionService(fakes.transport, fakes.clock, fakes.logger);
+    const id = await svc.start(TARGET);
+
+    await svc.sendChunk(TARGET, id, Buffer.from('aaaa').toString('base64'));
+    await svc.sendChunk(TARGET, id, Buffer.from('bb').toString('base64'));
+    fakes.logs.length = 0;
+    fakes.advanceClock(1_234);
+
+    await svc.stop(TARGET, id);
+
+    expect(fakes.logs[0]).toMatchObject({
+      message: 'Assistant voice session ended',
+      details: { sessionId: id, chunks: 2, bytes: 6, durationMs: 1_234 },
+    });
+    expect(svc._trackedSessions()).toEqual([]);
+  });
+
+  it('still emits a summary log when stopping an untracked session', async () => {
+    const fakes = makeFakes();
+    const svc = new VoiceSessionService(fakes.transport, fakes.clock, fakes.logger);
+
+    await svc.stop(TARGET, 999);
+
+    expect(fakes.logs[0]).toMatchObject({
+      message: 'Assistant voice session ended',
+      details: { sessionId: 999, chunks: 0, bytes: 0, durationMs: undefined },
+    });
+  });
+});
+
+describe('VoiceSessionService.hasPending', () => {
+  it('forwards to the transport and returns the result', async () => {
+    const fakes = makeFakes({ pending: true });
+    const svc = new VoiceSessionService(fakes.transport, fakes.clock, fakes.logger);
+
+    await expect(svc.hasPending(TARGET)).resolves.toBe(true);
+    expect(fakes.transportCalls).toContainEqual({
+      op: 'hasPending',
+      host: TARGET.host,
+      macAddress: TARGET.macAddress,
+    });
+  });
+});
+
+describe('VoiceSessionService — multiple concurrent sessions', () => {
+  it('tracks stats per-sessionId independently', async () => {
+    const fakes = makeFakes();
+    const transport = fakes.transport;
+    let next = 100;
+    transport.start = (host, macAddress) => {
+      fakes.transportCalls.push({ op: 'start', host, macAddress });
+      next += 1;
+      return Promise.resolve(next);
+    };
+
+    const svc = new VoiceSessionService(transport, fakes.clock, fakes.logger);
+    const idA = await svc.start(TARGET);
+    const idB = await svc.start(TARGET);
+    expect(idA).not.toBe(idB);
+
+    await svc.sendChunk(TARGET, idA, Buffer.from('x').toString('base64'));
+    await svc.sendChunk(TARGET, idB, Buffer.from('yy').toString('base64'));
+    await svc.sendChunk(TARGET, idB, Buffer.from('zzz').toString('base64'));
+
+    await svc.stop(TARGET, idA);
+    const stopA = fakes.logs.at(-1);
+    expect(stopA?.details).toMatchObject({ sessionId: idA, chunks: 1, bytes: 1 });
+
+    await svc.stop(TARGET, idB);
+    const stopB = fakes.logs.at(-1);
+    expect(stopB?.details).toMatchObject({ sessionId: idB, chunks: 2, bytes: 5 });
+  });
+});

--- a/src/main/device/googleTvAdapter.ts
+++ b/src/main/device/googleTvAdapter.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import { app } from 'electron';
 
+import { VoiceSessionService } from '../../backend/voice/VoiceSessionService';
 import type {
   BootstrapState,
   CommandDispatchRequest,
@@ -39,10 +40,29 @@ export class GoogleTvAdapter implements DeviceAdapter {
 
   private scanPromise: Promise<DiscoveredDevice[]> | undefined;
 
-  private assistantVoiceStats = new Map<
-    number,
-    { chunks: number; bytes: number; startedAt: number }
-  >();
+  // PR-5b: voice-session lifecycle (stats accounting + progress logging)
+  // is owned by VoiceSessionService now. Constructor-injected with a
+  // production default that wires it to the singleton bridge + logger +
+  // system clock — tests / future callers can pass their own.
+  private readonly voiceSessions: VoiceSessionService;
+
+  constructor(voiceSessions?: VoiceSessionService) {
+    this.voiceSessions =
+      voiceSessions ??
+      new VoiceSessionService(
+        {
+          start: (host, macAddress) => androidTvRemoteBridge.startAssistantVoice(host, macAddress),
+          sendChunk: (host, sessionId, chunk, macAddress) =>
+            androidTvRemoteBridge.sendAssistantVoiceChunk(host, sessionId, chunk, macAddress),
+          stop: (host, sessionId, macAddress) =>
+            androidTvRemoteBridge.stopAssistantVoice(host, sessionId, macAddress),
+          hasPending: (host, macAddress) =>
+            androidTvRemoteBridge.hasPendingAssistantVoiceSession(host, macAddress),
+        },
+        { now: () => Date.now() },
+        { info: (scope, message, details) => logInfo(scope, message, details) }
+      );
+  }
 
   async listDevices(): Promise<SavedDevice[]> {
     return readDevices();
@@ -420,91 +440,59 @@ export class GoogleTvAdapter implements DeviceAdapter {
     );
   }
 
+  // PR-5b: delegate the four voice-session operations to VoiceSessionService.
+  // The adapter is responsible only for: (a) gating on activeDevice, and
+  // (b) translating activeDevice → VoiceSessionTarget.
+
   async startAssistantVoice(): Promise<number> {
     if (!this.activeDevice) {
       throw new Error('No active device connected.');
     }
-
-    const sessionId = await androidTvRemoteBridge.startAssistantVoice(
-      this.activeDevice.host,
-      this.activeDevice.macAddress
-    );
-    await logInfo('adapter', 'Assistant voice session started', {
+    return this.voiceSessions.start({
       deviceId: this.activeDevice.id,
       host: this.activeDevice.host,
-      sessionId,
+      macAddress: this.activeDevice.macAddress,
     });
-    this.assistantVoiceStats.set(sessionId, { chunks: 0, bytes: 0, startedAt: Date.now() });
-    return sessionId;
   }
 
   async sendAssistantVoiceChunk(sessionId: number, chunkBase64: string): Promise<void> {
     if (!this.activeDevice) {
       throw new Error('No active device connected.');
     }
-
-    const chunk = Buffer.from(chunkBase64, 'base64');
-    await androidTvRemoteBridge.sendAssistantVoiceChunk(
-      this.activeDevice.host,
-      sessionId,
-      chunk,
-      this.activeDevice.macAddress
-    );
-
-    const stats = this.assistantVoiceStats.get(sessionId);
-    if (stats) {
-      stats.chunks += 1;
-      stats.bytes += chunk.length;
-      if (stats.chunks % 10 === 0) {
-        await logInfo('adapter', 'Assistant voice chunk progress', {
-          deviceId: this.activeDevice.id,
-          host: this.activeDevice.host,
-          sessionId,
-          chunks: stats.chunks,
-          bytes: stats.bytes,
-        });
-      }
-    } else {
-      await logInfo('adapter', 'Assistant voice chunk sent without tracked session', {
+    await this.voiceSessions.sendChunk(
+      {
         deviceId: this.activeDevice.id,
         host: this.activeDevice.host,
-        sessionId,
-        bytes: chunk.length,
-      });
-    }
+        macAddress: this.activeDevice.macAddress,
+      },
+      sessionId,
+      chunkBase64
+    );
   }
 
   async stopAssistantVoice(sessionId: number): Promise<void> {
     if (!this.activeDevice) {
       throw new Error('No active device connected.');
     }
-
-    await androidTvRemoteBridge.stopAssistantVoice(
-      this.activeDevice.host,
-      sessionId,
-      this.activeDevice.macAddress
+    await this.voiceSessions.stop(
+      {
+        deviceId: this.activeDevice.id,
+        host: this.activeDevice.host,
+        macAddress: this.activeDevice.macAddress,
+      },
+      sessionId
     );
-    const stats = this.assistantVoiceStats.get(sessionId);
-    this.assistantVoiceStats.delete(sessionId);
-    await logInfo('adapter', 'Assistant voice session ended', {
-      deviceId: this.activeDevice.id,
-      host: this.activeDevice.host,
-      sessionId,
-      chunks: stats?.chunks ?? 0,
-      bytes: stats?.bytes ?? 0,
-      durationMs: stats ? Date.now() - stats.startedAt : undefined,
-    });
   }
 
   async hasPendingAssistantVoiceSession(): Promise<boolean> {
     if (!this.activeDevice) {
       return false;
     }
-
-    return androidTvRemoteBridge.hasPendingAssistantVoiceSession(
-      this.activeDevice.host,
-      this.activeDevice.macAddress
-    );
+    return this.voiceSessions.hasPending({
+      deviceId: this.activeDevice.id,
+      host: this.activeDevice.host,
+      macAddress: this.activeDevice.macAddress,
+    });
   }
 
   getCapabilities(): Promise<DeviceCapabilities> {


### PR DESCRIPTION
## PR-5b — Extract `VoiceSessionService` from `GoogleTvAdapter`

**Wave 5 / Group A** (part of the de-risked PR-5 split — the biggest of the three).

### Why

`GoogleTvAdapter` was 523 LOC including ~95 lines of voice-session lifecycle: stats accounting (`assistantVoiceStats` map), decoded-chunk handling, periodic progress logging, summary logging on stop. None of that is testable without standing up the whole adapter + the singleton bridge + a real `logInfo` writing to disk.

Worse, every future device kind (Apple TV in a future milestone, plus any hypothetical Roku / webOS voice integration) would have to either duplicate this lifecycle or shoehorn into the adapter's god-class.

### What changed

#### New module: `src/backend/voice/VoiceSessionService.ts`

A pure backend service that owns the lifecycle. Depends only on three tiny ports:

```ts
interface IVoiceTransport {
  start(host, macAddress?): Promise<number>;
  sendChunk(host, sessionId, chunk, macAddress?): Promise<void>;
  stop(host, sessionId, macAddress?): Promise<void>;
  hasPending(host, macAddress?): Promise<boolean>;
}
interface IClock      { now(): number; }
interface IVoiceLogger { info(scope, message, details?): Promise<void>; }
```

The service:
- Decodes base64 chunks into `Buffer`.
- Tracks `{ chunks, bytes, startedAt }` per session id in an internal `Map`.
- Emits `'Assistant voice session started'` on start, `'Assistant voice chunk progress'` every 10 chunks (constant `VOICE_PROGRESS_LOG_EVERY_N_CHUNKS`, identical to the previous inline magic number), `'Assistant voice session ended'` on stop (with chunks/bytes/durationMs).
- If a chunk arrives for an unknown session id (orphan), it's still forwarded to the transport but a warning-grade `'sent without tracked session'` log line is emitted.

#### `src/main/device/googleTvAdapter.ts`

- Adds a new constructor that takes an optional `VoiceSessionService` and defaults to a production instance wired to:
  - `androidTvRemoteBridge` (the four voice methods)
  - `Date.now`
  - `logInfo`
- Replaces the 4 voice methods with 6–10 line delegates that gate on `activeDevice` and translate to `VoiceSessionTarget`.
- Deletes the private `assistantVoiceStats` map (now owned by the service).

#### `src/backend/voice/__tests__/VoiceSessionService.test.ts` — 8 new tests

| Test | Asserts |
|---|---|
| `start` returns transport id + logs start | id round-trip, log details parity |
| `sendChunk` forwards decoded chunk + increments stats | byte count from base64 decode, no progress log on chunk #1 |
| every 10 chunks emits progress log | parity check against `VOICE_PROGRESS_LOG_EVERY_N_CHUNKS` |
| chunk on untracked session emits warning log | orphan path |
| `stop` reports chunks / bytes / durationMs | uses injected clock; full summary fields |
| `stop` on untracked session still emits summary | zeros + `durationMs: undefined` |
| `hasPending` forwards transport result | passes through with no side effects |
| concurrent sessions track independent stats | two simultaneous sessions, summary parity |

### Validation

- typecheck (renderer + electron + backend): clean
- lint: 0 errors
- format: clean
- test: 135 / 135 (was 127; +8 from this PR)
- build: succeeds, bundle size unchanged

### Why this is safe

- **Behavior is byte-identical.** Log scope / message / detail fields preserved exactly (the new tests assert structural equality against the strings the old inline code used).
- **Production defaults wire to the existing singletons.** No call sites moved; the adapter just delegates.
- **The Google TV bridge surface (`androidTvRemoteBridge.startAssistantVoice` etc.) is unchanged** — this PR only repackages who calls it.
- **Backend non-regression gates** (protocol codec, cert migration, identity matching, IPC channel parity) unchanged — none of them touch the voice lifecycle.

### Risk

Low-medium. Touches `GoogleTvAdapter` which is in the device hot path, but the 4 voice methods are leaf calls that are exercised independently of pairing / connect / remote command. If anything regresses, it's confined to the assistant-voice button in the UI.
