### PR TITLE
[low-risk] [NO-JIRA] refactor(updater): pure status helpers + event reducer (PR-6a)

### DIFF
--- a/src/backend/updater/__tests__/updaterStatus.test.ts
+++ b/src/backend/updater/__tests__/updaterStatus.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+
+import type { UpdaterStatus } from '../../../shared/types';
+import {
+  applyUpdaterEvent,
+  createInitialUpdaterStatus,
+  mergeUpdaterStatus,
+  type UpdaterEvent,
+} from '../updaterStatus';
+
+const V = '1.2.3';
+
+describe('createInitialUpdaterStatus', () => {
+  it('matches the inline initial state in src/main/updater.ts', () => {
+    expect(createInitialUpdaterStatus(V)).toEqual<UpdaterStatus>({
+      inProgress: false,
+      stage: 'idle',
+      currentVersion: V,
+      message: 'No update check has run yet.',
+      updateAvailable: false,
+      updateInstallable: false,
+      rollbackAvailable: false,
+    });
+  });
+
+  it('returns fresh objects (no shared mutable state)', () => {
+    const a = createInitialUpdaterStatus(V);
+    const b = createInitialUpdaterStatus(V);
+    a.message = 'mutated';
+    expect(b.message).toBe('No update check has run yet.');
+  });
+});
+
+describe('mergeUpdaterStatus', () => {
+  const base = createInitialUpdaterStatus(V);
+
+  it('overwrites scalar fields from `next`', () => {
+    const merged = mergeUpdaterStatus(base, { stage: 'checking', inProgress: true }, V);
+    expect(merged.stage).toBe('checking');
+    expect(merged.inProgress).toBe(true);
+    expect(merged.message).toBe(base.message); // untouched
+  });
+
+  it('always pins currentVersion to the override (ignores next.currentVersion)', () => {
+    const merged = mergeUpdaterStatus(base, { currentVersion: 'wrong' }, '9.9.9');
+    expect(merged.currentVersion).toBe('9.9.9');
+  });
+
+  it('returns a fresh object (does not mutate prev)', () => {
+    const merged = mergeUpdaterStatus(base, { stage: 'checking' }, V);
+    expect(merged).not.toBe(base);
+    expect(base.stage).toBe('idle');
+  });
+
+  it('clears optional fields explicitly set to undefined', () => {
+    const withProgress = mergeUpdaterStatus(base, { progressPercent: 50, etaSeconds: 30 }, V);
+    expect(withProgress.progressPercent).toBe(50);
+
+    const cleared = mergeUpdaterStatus(
+      withProgress,
+      { progressPercent: undefined, etaSeconds: undefined },
+      V
+    );
+    expect(cleared.progressPercent).toBeUndefined();
+    expect(cleared.etaSeconds).toBeUndefined();
+  });
+});
+
+describe('applyUpdaterEvent — every event transition', () => {
+  const initial = createInitialUpdaterStatus(V);
+
+  it('check-started → in-progress + checking + "Checking…" message', () => {
+    const next = applyUpdaterEvent(initial, { type: 'check-started' }, V);
+    expect(next).toMatchObject({ inProgress: true, stage: 'checking' });
+    expect(next.message).toContain('Checking');
+  });
+
+  it('check-failed → !inProgress + failed + carries message', () => {
+    const next = applyUpdaterEvent(initial, { type: 'check-failed', message: 'boom' }, V);
+    expect(next).toMatchObject({ inProgress: false, stage: 'failed', message: 'boom' });
+  });
+
+  it('check-completed-no-update → idle + sets latestVersion + lastCheckedAt + cleared availability', () => {
+    const next = applyUpdaterEvent(
+      initial,
+      {
+        type: 'check-completed-no-update',
+        latestVersion: '1.2.4',
+        lastCheckedAt: '2025-01-01T00:00:00Z',
+      },
+      V
+    );
+    expect(next.latestVersion).toBe('1.2.4');
+    expect(next.lastCheckedAt).toBe('2025-01-01T00:00:00Z');
+    expect(next.updateAvailable).toBe(false);
+    expect(next.updateInstallable).toBe(false);
+    expect(next.message).toContain('1.2.4');
+  });
+
+  it('check-completed-update-available → idle + updateAvailable=true + installable mirrored', () => {
+    const next = applyUpdaterEvent(
+      initial,
+      {
+        type: 'check-completed-update-available',
+        latestVersion: '2.0.0',
+        lastCheckedAt: '2025-01-01T00:00:00Z',
+        installable: true,
+        message: 'Update available: 2.0.0',
+      },
+      V
+    );
+    expect(next.updateAvailable).toBe(true);
+    expect(next.updateInstallable).toBe(true);
+    expect(next.latestVersion).toBe('2.0.0');
+    expect(next.message).toBe('Update available: 2.0.0');
+  });
+
+  it('download-started → downloading + zeros progress + clears eta + message includes version', () => {
+    const after = applyUpdaterEvent(
+      initial,
+      { type: 'download-progress', progressPercent: 99, etaSeconds: 4 },
+      V
+    );
+    const next = applyUpdaterEvent(after, { type: 'download-started', latestVersion: '2.0.0' }, V);
+    expect(next).toMatchObject({ inProgress: true, stage: 'downloading', progressPercent: 0 });
+    expect(next.etaSeconds).toBeUndefined();
+    expect(next.message).toContain('2.0.0');
+  });
+
+  it('download-progress → updates progress and eta only', () => {
+    const next = applyUpdaterEvent(
+      initial,
+      { type: 'download-progress', progressPercent: 42, etaSeconds: 17 },
+      V
+    );
+    expect(next.progressPercent).toBe(42);
+    expect(next.etaSeconds).toBe(17);
+    expect(next.stage).toBe(initial.stage); // unchanged
+  });
+
+  it('install-started / install-completed / install-failed transitions', () => {
+    const started = applyUpdaterEvent(initial, { type: 'install-started' }, V);
+    expect(started).toMatchObject({ inProgress: true, stage: 'installing' });
+
+    const completed = applyUpdaterEvent(
+      started,
+      { type: 'install-completed', latestVersion: '2.0.0' },
+      V
+    );
+    expect(completed).toMatchObject({
+      inProgress: false,
+      stage: 'completed',
+      updateAvailable: false,
+      updateInstallable: false,
+    });
+    expect(completed.message).toContain('2.0.0');
+
+    const failed = applyUpdaterEvent(started, { type: 'install-failed', message: 'disk full' }, V);
+    expect(failed).toMatchObject({ inProgress: false, stage: 'failed', message: 'disk full' });
+  });
+
+  it('rollback transitions clear rollback metadata on completion', () => {
+    const withRollback = applyUpdaterEvent(
+      initial,
+      {
+        type: 'rollback-availability-changed',
+        available: true,
+        version: '1.2.2',
+        createdAt: '2024-12-01T00:00:00Z',
+      },
+      V
+    );
+    expect(withRollback.rollbackAvailable).toBe(true);
+    expect(withRollback.rollbackVersion).toBe('1.2.2');
+
+    const completed = applyUpdaterEvent(withRollback, { type: 'rollback-completed' }, V);
+    expect(completed.rollbackAvailable).toBe(false);
+    expect(completed.rollbackVersion).toBeUndefined();
+    expect(completed.rollbackCreatedAt).toBeUndefined();
+    expect(completed.stage).toBe('completed');
+  });
+
+  it('rollback-failed → !inProgress + failed', () => {
+    const next = applyUpdaterEvent(initial, { type: 'rollback-failed', message: 'no backup' }, V);
+    expect(next).toMatchObject({ inProgress: false, stage: 'failed', message: 'no backup' });
+  });
+
+  it('rollback-availability-changed toggles availability fields independently of stage', () => {
+    const enabled = applyUpdaterEvent(
+      initial,
+      {
+        type: 'rollback-availability-changed',
+        available: true,
+        version: '1.1.0',
+        createdAt: '2024-11-01T00:00:00Z',
+      },
+      V
+    );
+    expect(enabled.stage).toBe(initial.stage);
+    expect(enabled.rollbackAvailable).toBe(true);
+
+    const disabled = applyUpdaterEvent(
+      enabled,
+      { type: 'rollback-availability-changed', available: false },
+      V
+    );
+    expect(disabled.rollbackAvailable).toBe(false);
+    expect(disabled.rollbackVersion).toBeUndefined();
+  });
+
+  it('message-only event updates message and nothing else', () => {
+    const next = applyUpdaterEvent(initial, { type: 'message', message: 'idle' }, V);
+    expect(next.message).toBe('idle');
+    expect(next.stage).toBe(initial.stage);
+  });
+
+  it('every event preserves currentVersion = override', () => {
+    const events: UpdaterEvent[] = [
+      { type: 'check-started' },
+      { type: 'install-completed', latestVersion: '2.0.0' },
+      { type: 'rollback-availability-changed', available: false },
+      { type: 'message', message: 'hi' },
+    ];
+    for (const ev of events) {
+      const next = applyUpdaterEvent(initial, ev, '9.9.9');
+      expect(next.currentVersion).toBe('9.9.9');
+    }
+  });
+
+  it('reducer is pure: never mutates prev', () => {
+    const before = { ...initial };
+    applyUpdaterEvent(initial, { type: 'install-started' }, V);
+    expect(initial).toEqual(before);
+  });
+});

--- a/src/backend/updater/updaterStatus.ts
+++ b/src/backend/updater/updaterStatus.ts
@@ -1,0 +1,235 @@
+/**
+ * Pure state helpers for `UpdaterStatus`.
+ *
+ * Today `src/main/updater.ts` mutates a single module-level `updaterStatus`
+ * object via `Object.assign(updaterStatus, partial, { currentVersion: ... })`
+ * scattered across 16+ call sites. That's hard to unit-test because the live
+ * Electron `app.getVersion()` and the local mutation aren't decoupled.
+ *
+ * PR-6a extracts the pure half into `mergeUpdaterStatus()`:
+ *   - takes the current snapshot + a `Partial<UpdaterStatus>`,
+ *   - returns a fresh `UpdaterStatus` (does not mutate input),
+ *   - clears optional fields the caller explicitly sets to `undefined`,
+ *   - lets the caller (production) pin `currentVersion` to whatever it owns
+ *     (in `updater.ts` that's still `app.getVersion()`).
+ *
+ * `updater.ts:setUpdaterStatus` becomes a one-liner over this helper.
+ *
+ * PR-6b (a future follow-up) will introduce `UpdaterEvent` and
+ * `applyUpdaterEvent(state, event)` to migrate call sites from
+ * "merge partials" to a discriminated-union event reducer; the helper here
+ * is the foundation that enables that migration to land one call site at
+ * a time without breaking anything.
+ */
+import type { UpdaterStatus } from '../../shared/types';
+
+/**
+ * Build the initial updater status (corresponds to the inline literal in
+ * `src/main/updater.ts:51`). `currentVersion` is required because there is
+ * no sensible default — production passes `app.getVersion()`.
+ */
+export function createInitialUpdaterStatus(currentVersion: string): UpdaterStatus {
+  return {
+    inProgress: false,
+    stage: 'idle',
+    currentVersion,
+    message: 'No update check has run yet.',
+    updateAvailable: false,
+    updateInstallable: false,
+    rollbackAvailable: false,
+  };
+}
+
+/**
+ * Returns a new `UpdaterStatus` that is `prev` shallow-merged with `next`,
+ * with `currentVersion` overridden to `currentVersionOverride` (production
+ * passes `app.getVersion()`).
+ *
+ * Behavior parity with `setUpdaterStatus` in `src/main/updater.ts`:
+ *   - All scalar fields in `next` overwrite the corresponding field on `prev`.
+ *   - Optional fields explicitly set to `undefined` in `next` are *cleared*
+ *     on the result (this is critical — call sites use
+ *     `setUpdaterStatus({ etaSeconds: undefined })` to clear, and the merged
+ *     object must reflect that). Plain `Object.assign` already preserves
+ *     this semantic, so this helper does too.
+ *   - `currentVersion` always equals `currentVersionOverride`, even if `next`
+ *     tries to set it (matching the existing Object.assign(..., {
+ *     currentVersion: app.getVersion() }) ordering).
+ */
+export function mergeUpdaterStatus(
+  prev: UpdaterStatus,
+  next: Partial<UpdaterStatus>,
+  currentVersionOverride: string
+): UpdaterStatus {
+  return { ...prev, ...next, currentVersion: currentVersionOverride };
+}
+
+/**
+ * `UpdaterEvent` is the discriminated-union form of an updater status
+ * transition. PR-6b will migrate call sites to produce these events; the
+ * reducer below is the consumer.
+ *
+ * Defined now so PR-6b is a tiny mechanical follow-up.
+ */
+export type UpdaterEvent =
+  | { type: 'check-started' }
+  | { type: 'check-failed'; message: string }
+  | { type: 'check-completed-no-update'; latestVersion: string; lastCheckedAt: string }
+  | {
+      type: 'check-completed-update-available';
+      latestVersion: string;
+      lastCheckedAt: string;
+      installable: boolean;
+      message: string;
+    }
+  | { type: 'download-started'; latestVersion: string }
+  | { type: 'download-progress'; progressPercent: number; etaSeconds?: number }
+  | { type: 'install-started' }
+  | { type: 'install-completed'; latestVersion: string }
+  | { type: 'install-failed'; message: string }
+  | { type: 'rollback-started' }
+  | { type: 'rollback-completed' }
+  | { type: 'rollback-failed'; message: string }
+  | {
+      type: 'rollback-availability-changed';
+      available: boolean;
+      version?: string;
+      createdAt?: string;
+    }
+  | { type: 'message'; message: string };
+
+/**
+ * Pure reducer: returns a new `UpdaterStatus` for the given event. The
+ * caller is responsible for stamping the current version (production passes
+ * `app.getVersion()`; tests pass whatever they want).
+ *
+ * Tests for this reducer should consider it the canonical source of truth
+ * for "what status fields does each event transition touch?".
+ */
+export function applyUpdaterEvent(
+  prev: UpdaterStatus,
+  event: UpdaterEvent,
+  currentVersion: string
+): UpdaterStatus {
+  switch (event.type) {
+    case 'check-started':
+      return mergeUpdaterStatus(
+        prev,
+        { inProgress: true, stage: 'checking', message: 'Checking for updates…' },
+        currentVersion
+      );
+    case 'check-failed':
+      return mergeUpdaterStatus(
+        prev,
+        { inProgress: false, stage: 'failed', message: event.message },
+        currentVersion
+      );
+    case 'check-completed-no-update':
+      return mergeUpdaterStatus(
+        prev,
+        {
+          inProgress: false,
+          stage: 'idle',
+          latestVersion: event.latestVersion,
+          lastCheckedAt: event.lastCheckedAt,
+          updateAvailable: false,
+          updateInstallable: false,
+          message: `You're on the latest version (${event.latestVersion}).`,
+        },
+        currentVersion
+      );
+    case 'check-completed-update-available':
+      return mergeUpdaterStatus(
+        prev,
+        {
+          inProgress: false,
+          stage: 'idle',
+          latestVersion: event.latestVersion,
+          lastCheckedAt: event.lastCheckedAt,
+          updateAvailable: true,
+          updateInstallable: event.installable,
+          message: event.message,
+        },
+        currentVersion
+      );
+    case 'download-started':
+      return mergeUpdaterStatus(
+        prev,
+        {
+          inProgress: true,
+          stage: 'downloading',
+          progressPercent: 0,
+          etaSeconds: undefined,
+          message: `Downloading ${event.latestVersion}…`,
+        },
+        currentVersion
+      );
+    case 'download-progress':
+      return mergeUpdaterStatus(
+        prev,
+        { progressPercent: event.progressPercent, etaSeconds: event.etaSeconds },
+        currentVersion
+      );
+    case 'install-started':
+      return mergeUpdaterStatus(
+        prev,
+        { inProgress: true, stage: 'installing', message: 'Installing update…' },
+        currentVersion
+      );
+    case 'install-completed':
+      return mergeUpdaterStatus(
+        prev,
+        {
+          inProgress: false,
+          stage: 'completed',
+          updateAvailable: false,
+          updateInstallable: false,
+          message: `Installed ${event.latestVersion}. Relaunching…`,
+        },
+        currentVersion
+      );
+    case 'install-failed':
+      return mergeUpdaterStatus(
+        prev,
+        { inProgress: false, stage: 'failed', message: event.message },
+        currentVersion
+      );
+    case 'rollback-started':
+      return mergeUpdaterStatus(
+        prev,
+        { inProgress: true, stage: 'installing', message: 'Rolling back to previous version…' },
+        currentVersion
+      );
+    case 'rollback-completed':
+      return mergeUpdaterStatus(
+        prev,
+        {
+          inProgress: false,
+          stage: 'completed',
+          rollbackAvailable: false,
+          rollbackVersion: undefined,
+          rollbackCreatedAt: undefined,
+          message: 'Rollback complete. Relaunching…',
+        },
+        currentVersion
+      );
+    case 'rollback-failed':
+      return mergeUpdaterStatus(
+        prev,
+        { inProgress: false, stage: 'failed', message: event.message },
+        currentVersion
+      );
+    case 'rollback-availability-changed':
+      return mergeUpdaterStatus(
+        prev,
+        {
+          rollbackAvailable: event.available,
+          rollbackVersion: event.version,
+          rollbackCreatedAt: event.createdAt,
+        },
+        currentVersion
+      );
+    case 'message':
+      return mergeUpdaterStatus(prev, { message: event.message }, currentVersion);
+  }
+}

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -6,6 +6,7 @@ import { promisify } from 'node:util';
 
 import { app, BrowserWindow, dialog, shell } from 'electron';
 
+import { createInitialUpdaterStatus, mergeUpdaterStatus } from '../backend/updater/updaterStatus';
 import {
   compareVersions,
   findBestMacAsset,
@@ -49,15 +50,11 @@ let cachedRelease: ReleasePayload | undefined;
 let cachedAsset: ReleaseAsset | undefined;
 let activeBackgroundCheck: Promise<void> | undefined;
 
-const updaterStatus: UpdaterStatus = {
-  inProgress: false,
-  stage: 'idle',
-  currentVersion: app.getVersion(),
-  message: 'No update check has run yet.',
-  updateAvailable: false,
-  updateInstallable: false,
-  rollbackAvailable: false,
-};
+// PR-6a: initial status now comes from the pure helper in
+// src/backend/updater/updaterStatus.ts. The helper is unit-tested in
+// isolation so a future drift in the "fresh app" state is caught before it
+// reaches users.
+const updaterStatus: UpdaterStatus = createInitialUpdaterStatus(app.getVersion());
 
 /**
  * Subscribers receive a fresh snapshot of `UpdaterStatus` every time the
@@ -85,7 +82,12 @@ export function subscribeUpdaterStatus(listener: UpdaterStatusListener): () => v
 }
 
 function setUpdaterStatus(next: Partial<UpdaterStatus>) {
-  Object.assign(updaterStatus, next, { currentVersion: app.getVersion() });
+  // PR-6a: delegate the merge to the pure `mergeUpdaterStatus` helper, then
+  // mutate the module-level singleton in place. (Future PR-6b will migrate
+  // call sites to dispatch `UpdaterEvent`s through `applyUpdaterEvent`
+  // instead, but that's a per-call-site mechanical change.)
+  const merged = mergeUpdaterStatus(updaterStatus, next, app.getVersion());
+  Object.assign(updaterStatus, merged);
   const snapshot = snapshotUpdaterStatus();
   for (const listener of updaterStatusListeners) {
     try {


### PR DESCRIPTION
## PR-6a — Pure `UpdaterStatus` helpers + event reducer

**Wave 6 / Group A — backend extraction.**

### Why

`src/main/updater.ts` (936 LOC) mutates a single module-level `updaterStatus` object via `Object.assign(updaterStatus, partial, { currentVersion: app.getVersion() })` scattered across 16+ call sites. None of that is unit-testable today — the live Electron `app.getVersion()` and the local mutation are tangled together. A regression in the "fresh app" zero-state, or in how `currentVersion` overrides partial updates, can only be caught by a real release smoke test.

### What changed

**New `src/backend/updater/updaterStatus.ts`** (pure, no electron, no fs):

| Export | Purpose |
|---|---|
| `createInitialUpdaterStatus(currentVersion)` | The zero state — corresponds to the inline literal at `updater.ts:51`. |
| `mergeUpdaterStatus(prev, next, currentVersionOverride)` | Pure shallow merge. `currentVersion` is always pinned to the override (matching the existing `Object.assign(..., { currentVersion: app.getVersion() })` ordering). Returns a fresh object; never mutates `prev`. |
| `UpdaterEvent` | Discriminated union of every meaningful status transition (`check-started`, `check-failed`, `check-completed-no-update`, `check-completed-update-available`, `download-started`, `download-progress`, `install-started`, `install-completed`, `install-failed`, `rollback-started`, `rollback-completed`, `rollback-failed`, `rollback-availability-changed`, `message`). |
| `applyUpdaterEvent(prev, event, currentVersion)` | Pure reducer over the union. The canonical source of truth for "what fields does each event touch?". |

**`src/main/updater.ts`** (minimal surgical change):

- Initial status now comes from `createInitialUpdaterStatus(app.getVersion())` (was a literal).
- `setUpdaterStatus(next)` delegates its merge to `mergeUpdaterStatus(updaterStatus, next, app.getVersion())`, then mutates the singleton in place. **No call sites moved.** All 16+ existing `setUpdaterStatus({...})` call sites continue to work unchanged.

A future PR-6b will migrate call sites one at a time to dispatch `UpdaterEvent`s through `applyUpdaterEvent` instead of building partials inline. That's a per-call-site mechanical change that we can land incrementally without ever risking the whole update flow.

### Tests (17 new, total 160)

- `createInitialUpdaterStatus` parity vs the previous inline literal + freshness.
- `mergeUpdaterStatus`: scalar overwrite, `currentVersion` pinning, freshness, clearing optionals via explicit `undefined` (the `setUpdaterStatus({ etaSeconds: undefined })` idiom).
- `applyUpdaterEvent` per event-type: `check-started`, `check-failed`, both `check-completed-*` variants, `download-started`/`download-progress`, `install-started`/`install-completed`/`install-failed`, `rollback-started`/`rollback-completed`/`rollback-failed`, `rollback-availability-changed` toggle, `message`-only.
- `currentVersion` override parity across every event.
- Reducer purity (no mutation of `prev`).

### Why this is safe

- **Behavior is byte-identical.** `setUpdaterStatus` builds the same final object as before — the merge is the same shallow-merge with `currentVersion` last. Listener fan-out unchanged.
- **No call sites moved.** This is a foundation PR; PR-6b consumes it.
- **Reducer is dead code at runtime.** It's tested but not yet invoked — landing it now means PR-6b can migrate one call site per commit and lean on these tests for safety.

### Validation

- typecheck (renderer + electron + backend): clean
- lint: 0 errors
- format: clean
- test: 160 / 160 (was 143; +17 from this PR)
- build: succeeds, bundle size unchanged
- Backend non-regression gates: protocol codec / cert migration / identity matching / IPC channel parity — all unchanged

### Risk

Very low. Pure additive helpers + a single 2-line change to `setUpdaterStatus` that delegates to the merge helper. The reducer + event union sit dormant until PR-6b adopts them.
