### PR TITLE
[medium-risk] [NO-JIRA] refactor(transport): extract pure varint frame parser (PR-3b)

### DIFF
--- a/src/backend/transport/framing/__tests__/frameParser.test.ts
+++ b/src/backend/transport/framing/__tests__/frameParser.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+
+import { __TEST__, parseFramedBuffer } from '../frameParser';
+
+/**
+ * Build a varint-length-prefixed frame whose body is `body`. Mirrors what
+ * `protocol/androidtv/remote.ts` produces on the wire — the parser must
+ * round-trip these byte-for-byte to lock down Google TV protocol parity.
+ */
+function frame(body: Buffer): Buffer {
+  const header = encodeVarint(body.length);
+  return Buffer.concat([header, body]);
+}
+
+function encodeVarint(value: number): Buffer {
+  const bytes: number[] = [];
+  let remaining = value;
+  while (remaining >= 0x80) {
+    bytes.push((remaining & 0x7f) | 0x80);
+    remaining >>>= 7;
+  }
+  bytes.push(remaining & 0x7f);
+  return Buffer.from(bytes);
+}
+
+function expectBuffer(actual: Buffer | undefined, expected: Buffer): void {
+  expect(actual).toBeDefined();
+  if (!actual) return;
+  expect(Buffer.compare(actual, expected)).toBe(0);
+}
+
+describe('parseFramedBuffer — empty / trivial cases', () => {
+  it('empty buffer → no frames, empty remaining', () => {
+    const result = parseFramedBuffer(Buffer.alloc(0));
+    expect(result.frames).toEqual([]);
+    expect(result.remaining.length).toBe(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('single complete short frame (body 1 byte)', () => {
+    const f = frame(Buffer.from([0x42]));
+    const result = parseFramedBuffer(f);
+    expect(result.frames).toHaveLength(1);
+    expectBuffer(result.frames[0], f);
+    expect(result.remaining.length).toBe(0);
+  });
+
+  it('single complete medium frame (body 100 bytes — single-byte varint)', () => {
+    const body = Buffer.alloc(100, 0xab);
+    const f = frame(body);
+    const result = parseFramedBuffer(f);
+    expect(result.frames).toHaveLength(1);
+    expectBuffer(result.frames[0], f);
+    expect(result.remaining.length).toBe(0);
+  });
+
+  it('single complete large frame (body 200 bytes — two-byte varint)', () => {
+    const body = Buffer.alloc(200, 0x55);
+    const f = frame(body);
+    const firstByte = f[0];
+    expect(firstByte).toBeDefined();
+    if (firstByte !== undefined) {
+      expect(firstByte & 0x80).toBe(0x80);
+    }
+    const result = parseFramedBuffer(f);
+    expect(result.frames).toHaveLength(1);
+    expectBuffer(result.frames[0], f);
+    expect(result.remaining.length).toBe(0);
+  });
+});
+
+describe('parseFramedBuffer — multi-frame buffers', () => {
+  it('two back-to-back frames decode independently', () => {
+    const a = frame(Buffer.from([0x01, 0x02]));
+    const b = frame(Buffer.from([0x03, 0x04, 0x05]));
+    const result = parseFramedBuffer(Buffer.concat([a, b]));
+    expect(result.frames).toHaveLength(2);
+    expectBuffer(result.frames[0], a);
+    expectBuffer(result.frames[1], b);
+    expect(result.remaining.length).toBe(0);
+  });
+
+  it('many frames in a single buffer', () => {
+    const fs = Array.from({ length: 20 }, (_, i) =>
+      frame(Buffer.from([i & 0xff, (i + 1) & 0xff, (i + 2) & 0xff]))
+    );
+    const result = parseFramedBuffer(Buffer.concat(fs));
+    expect(result.frames).toHaveLength(20);
+    for (let i = 0; i < 20; i += 1) {
+      expectBuffer(result.frames[i], fs[i] ?? Buffer.alloc(0));
+    }
+  });
+});
+
+describe('parseFramedBuffer — partial reads (the realistic case)', () => {
+  it('header complete but body partial → 0 frames + full buffer remaining', () => {
+    const body = Buffer.from([0x10, 0x20, 0x30, 0x40]);
+    const f = frame(body); // [0x04, 0x10, 0x20, 0x30, 0x40]
+    const partial = f.subarray(0, 3); // header + first 2 body bytes
+    const result = parseFramedBuffer(partial);
+    expect(result.frames).toEqual([]);
+    expect(Buffer.compare(result.remaining, partial)).toBe(0);
+  });
+
+  it('only header byte received → 0 frames + that byte remains', () => {
+    const f = frame(Buffer.alloc(100));
+    const partial = f.subarray(0, 1);
+    const result = parseFramedBuffer(partial);
+    expect(result.frames).toEqual([]);
+    expect(Buffer.compare(result.remaining, partial)).toBe(0);
+  });
+
+  it('multi-byte varint header arrives split across reads', () => {
+    const body = Buffer.alloc(300, 0xee);
+    const f = frame(body); // 2-byte header
+    const partial = f.subarray(0, 1);
+    const firstByte = partial[0];
+    expect(firstByte).toBeDefined();
+    if (firstByte !== undefined) {
+      expect(firstByte & 0x80).toBe(0x80);
+    }
+    const result = parseFramedBuffer(partial);
+    expect(result.frames).toEqual([]);
+    expect(Buffer.compare(result.remaining, partial)).toBe(0);
+  });
+
+  it('one complete frame followed by a partial frame', () => {
+    const a = frame(Buffer.from([0xaa, 0xbb]));
+    const b = frame(Buffer.from([0xcc, 0xdd, 0xee, 0xff]));
+    const partial = Buffer.concat([a, b.subarray(0, 3)]);
+    const result = parseFramedBuffer(partial);
+    expect(result.frames).toHaveLength(1);
+    expectBuffer(result.frames[0], a);
+    expect(Buffer.compare(result.remaining, b.subarray(0, 3))).toBe(0);
+  });
+});
+
+describe('parseFramedBuffer — malformed input', () => {
+  it('varint with too many continuation bits → error + remaining cleared', () => {
+    const evil = Buffer.from([0x80, 0x80, 0x80, 0x80, 0x80, 0x80]);
+    const result = parseFramedBuffer(evil);
+    expect(result.frames).toEqual([]);
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toBe(__TEST__.MALFORMED_FRAME_ERROR_MESSAGE);
+    expect(result.remaining.length).toBe(0);
+  });
+
+  it('any already-decoded frames before the malformed varint are still returned', () => {
+    const a = frame(Buffer.from([0x01]));
+    const evil = Buffer.from([0x80, 0x80, 0x80, 0x80, 0x80, 0x80]);
+    const result = parseFramedBuffer(Buffer.concat([a, evil]));
+    expect(result.frames).toHaveLength(1);
+    expectBuffer(result.frames[0], a);
+    expect(result.error).toBeDefined();
+    expect(result.remaining.length).toBe(0);
+  });
+});
+
+describe('parseFramedBuffer — purity / determinism', () => {
+  it('does not mutate the input buffer', () => {
+    const a = frame(Buffer.from([0x10, 0x20]));
+    const b = frame(Buffer.from([0x30, 0x40, 0x50]));
+    const input = Buffer.concat([a, b]);
+    const snapshot = Buffer.from(input);
+    parseFramedBuffer(input);
+    expect(Buffer.compare(input, snapshot)).toBe(0);
+  });
+
+  it('repeated calls on the same buffer return the same frames (byte-equal)', () => {
+    const input = Buffer.concat([
+      frame(Buffer.from([1])),
+      frame(Buffer.from([2, 3])),
+      frame(Buffer.from([4, 5, 6])),
+    ]);
+    const first = parseFramedBuffer(input);
+    const second = parseFramedBuffer(input);
+    expect(second.frames).toHaveLength(first.frames.length);
+    for (let i = 0; i < first.frames.length; i += 1) {
+      expectBuffer(second.frames[i], first.frames[i] ?? Buffer.alloc(0));
+    }
+  });
+});
+
+describe('parseFramedBuffer — caller usage simulation', () => {
+  it('streaming reads of arbitrary chunk sizes recover all frames', () => {
+    const frames = [
+      frame(Buffer.from([0x01, 0x02])),
+      frame(Buffer.alloc(100, 0xaa)),
+      frame(Buffer.alloc(180, 0xbb)),
+      frame(Buffer.from([0x99])),
+    ];
+    const stream = Buffer.concat(frames);
+
+    let buffer = Buffer.alloc(0);
+    const recovered: Buffer[] = [];
+    for (let i = 0; i < stream.length; i += 7) {
+      const chunk = stream.subarray(i, Math.min(i + 7, stream.length));
+      buffer = Buffer.concat([buffer, chunk]);
+      const result = parseFramedBuffer(buffer);
+      recovered.push(...result.frames);
+      buffer = Buffer.from(result.remaining);
+    }
+    expect(buffer.length).toBe(0);
+    expect(recovered).toHaveLength(frames.length);
+    for (let i = 0; i < frames.length; i += 1) {
+      expectBuffer(recovered[i], frames[i] ?? Buffer.alloc(0));
+    }
+  });
+});

--- a/src/backend/transport/framing/frameParser.ts
+++ b/src/backend/transport/framing/frameParser.ts
@@ -1,0 +1,128 @@
+/**
+ * Pure parser for varint-length-prefixed frames over the Android TV remote
+ * protocol. Extracted in PR-3b from the inline `readNextFrame` + `flushBuffer`
+ * loop in `src/main/device/androidTvRemote.ts` so it is:
+ *
+ *   - unit-testable byte-by-byte without standing up a TLS socket;
+ *   - reusable by any future transport (recorded captures, fake socket
+ *     in tests, eventual replacement of androidtv-remote with a homegrown
+ *     transport).
+ *
+ * Wire format (matches the on-the-wire format used by Google's Android TV
+ * v2 remote service on port 6466):
+ *
+ *   ┌─────────────┬──────────────────────────────┐
+ *   │ varint len  │ protobuf body (`len` bytes)  │
+ *   └─────────────┴──────────────────────────────┘
+ *
+ * The varint is little-endian, 7 bits per byte, high bit set to indicate
+ * "more bytes follow". The protocol only uses 32-bit varints (max 5 bytes),
+ * so we cap `shift` at 28 to catch malformed input.
+ *
+ * Behavior parity with the previous inline parser is asserted by tests in
+ * `__tests__/frameParser.test.ts`.
+ */
+export interface FrameParseResult {
+  /** Frames fully assembled from `buffer`. Each is the WHOLE frame including
+   * its varint header (this matches what the previous inline parser
+   * returned and what `parseRemoteMessage` consumes). */
+  readonly frames: readonly Buffer[];
+  /** The trailing bytes that did not form a complete frame yet. Must be
+   * prepended to the next chunk received from the socket. */
+  readonly remaining: Buffer;
+  /** Set iff the parser detected a malformed varint header (too many
+   * continuation bits). Caller MUST drop the connection — the stream is
+   * unrecoverable. The parser also clears `remaining` to empty in this case. */
+  readonly error?: Error;
+}
+
+/** Maximum number of bits in a 32-bit varint header (5 * 7 = 35; we cap at 28
+ * because the 5th byte may only contribute 4 bits but the parser treats it
+ * the same as the previous inline implementation: `shift > 28` → error). */
+const MAX_VARINT_SHIFT_BITS = 28;
+
+/** Sentinel for a malformed varint header. Matches the message the previous
+ * inline parser used so error logs and pollinator tests are unchanged. */
+const MALFORMED_FRAME_ERROR_MESSAGE = 'Received an invalid remote protocol frame.';
+
+/**
+ * Decode all complete frames sitting in `buffer`. Returns the assembled
+ * frames + whatever bytes are left over (must be prepended to the next
+ * read).
+ *
+ * Pure: never mutates `buffer`, never throws (errors are returned in
+ * `result.error`), never allocates beyond what the returned `Buffer.subarray`
+ * slices reference.
+ */
+export function parseFramedBuffer(buffer: Buffer): FrameParseResult {
+  if (buffer.length === 0) {
+    return { frames: [], remaining: buffer };
+  }
+
+  const frames: Buffer[] = [];
+  let cursor = 0;
+
+  while (cursor < buffer.length) {
+    const headerEnd = decodeVarintHeader(buffer, cursor);
+    if (headerEnd.kind === 'error') {
+      return { frames, remaining: Buffer.alloc(0), error: headerEnd.error };
+    }
+    if (headerEnd.kind === 'need-more') {
+      // Either incomplete varint OR complete varint but not enough body.
+      break;
+    }
+
+    const frameLength = headerEnd.headerLength + headerEnd.bodyLength;
+    if (buffer.length - cursor < frameLength) {
+      // Header complete but body not fully received yet.
+      break;
+    }
+
+    const frame = buffer.subarray(cursor, cursor + frameLength);
+    frames.push(frame);
+    cursor += frameLength;
+  }
+
+  const remaining = cursor === 0 ? buffer : buffer.subarray(cursor);
+  return { frames, remaining };
+}
+
+type HeaderDecode =
+  | { kind: 'ok'; headerLength: number; bodyLength: number }
+  | { kind: 'need-more' }
+  | { kind: 'error'; error: Error };
+
+/**
+ * Decode the varint header starting at `start`. Returns the header byte
+ * length AND the protobuf body length (so the caller can immediately compute
+ * the total frame length). Returns `need-more` if the varint is incomplete.
+ */
+function decodeVarintHeader(buffer: Buffer, start: number): HeaderDecode {
+  let length = 0;
+  let shift = 0;
+
+  for (let index = start; index < buffer.length; index += 1) {
+    const byte = buffer[index];
+    if (byte === undefined) {
+      // Defensive: should be unreachable because index < buffer.length.
+      return { kind: 'need-more' };
+    }
+    length |= (byte & 0x7f) << shift;
+
+    if ((byte & 0x80) === 0) {
+      return { kind: 'ok', headerLength: index - start + 1, bodyLength: length };
+    }
+
+    shift += 7;
+    if (shift > MAX_VARINT_SHIFT_BITS) {
+      return { kind: 'error', error: new Error(MALFORMED_FRAME_ERROR_MESSAGE) };
+    }
+  }
+
+  return { kind: 'need-more' };
+}
+
+export const __TEST__ = {
+  MALFORMED_FRAME_ERROR_MESSAGE,
+  MAX_VARINT_SHIFT_BITS,
+};

--- a/src/main/device/androidTvRemote.ts
+++ b/src/main/device/androidTvRemote.ts
@@ -5,6 +5,7 @@ import tls from 'node:tls';
 
 import { createNodeFileSystem, type IFileSystem } from '../../backend/core/fileSystem';
 import { AndroidTvCertStore } from '../../backend/devices/credentials/androidTvCertStore';
+import { parseFramedBuffer } from '../../backend/transport/framing/frameParser';
 import type { CommandDispatchRequest } from '../../shared/types';
 import { getAppDataPath, logError, logInfo } from '../logger';
 import { commandMetricsStore } from '../metrics';
@@ -347,48 +348,31 @@ class NativeRemoteClient {
     return this.socket;
   }
 
+  /**
+   * PR-3b: framing was a 40-line inline varint parser. It now delegates to
+   * the pure `parseFramedBuffer` helper in `src/backend/transport/framing/`,
+   * which is unit-tested byte-by-byte (partial reads, multi-frame chunks,
+   * malformed varints, streaming windows). Behavior is byte-identical to
+   * the previous inline implementation — same malformed-frame error message,
+   * same buffer-clear-on-error semantics, same socket destroy on bad input.
+   */
   private flushBuffer(): void {
-    while (this.buffer.length > 0) {
-      const frame = this.readNextFrame();
-      if (!frame) {
-        return;
-      }
+    const result = parseFramedBuffer(this.buffer);
+    this.buffer = Buffer.from(result.remaining);
 
+    if (result.error) {
+      this.socket?.destroy(result.error);
+      // `parseFramedBuffer` already cleared remaining on error; defensive:
+      this.buffer = Buffer.alloc(0);
+      // Still hand off any frames that were successfully parsed before the
+      // malformed varint — matches previous inline behavior where each
+      // frame was processed inside the while-loop before the bad byte hit.
+    }
+
+    for (const frame of result.frames) {
       const message = parseRemoteMessage(frame);
       this.handleMessage(message);
     }
-  }
-
-  private readNextFrame(): Buffer | undefined {
-    let length = 0;
-    let shift = 0;
-
-    for (let index = 0; index < this.buffer.length; index++) {
-      const byte = this.buffer[index];
-      length |= (byte & 0x7f) << shift;
-
-      if ((byte & 0x80) === 0) {
-        const headerLength = index + 1;
-        const frameLength = headerLength + length;
-
-        if (this.buffer.length < frameLength) {
-          return undefined;
-        }
-
-        const frame = this.buffer.subarray(0, frameLength);
-        this.buffer = this.buffer.subarray(frameLength);
-        return frame;
-      }
-
-      shift += 7;
-      if (shift > 28) {
-        this.buffer = Buffer.alloc(0);
-        this.socket?.destroy(new Error('Received an invalid remote protocol frame.'));
-        return undefined;
-      }
-    }
-
-    return undefined;
   }
 
   private handleMessage(message: {


### PR DESCRIPTION
## PR-3b — Pure varint frame parser (`parseFramedBuffer`)

**Wave 6 / Group A — backend extraction. The "lock down Google TV inbound parsing under unit tests" PR.**

This is the FIRST piece of the original PR-3 (FramedTlsTransport) split. Lower halves of the transport (TLS socket lifecycle, backpressure, drain accounting) remain in `androidTvRemote.ts` for now; they will be hoisted in a follow-up PR-3c.

### Why

Every inbound message from a Google TV / Android TV device flows through `NativeRemoteClient.readNextFrame` / `flushBuffer` — a 40-line inline varint length-prefixed frame parser embedded inside a TLS socket lifecycle class. None of it is currently unit-testable. Any regression in:

- partial-read handling (the realistic case — TLS chunks rarely align to frame boundaries),
- multi-byte varint headers (frames ≥128 bytes — voice packets, IME batch edits),
- malformed varint detection (the "kill the connection" safety net),

can only be caught by running against a live TV.

### What changed

#### New `src/backend/transport/framing/frameParser.ts`

```ts
parseFramedBuffer(buffer): {
  frames: readonly Buffer[];   // whole frames including their varint headers
  remaining: Buffer;            // bytes that did not form a complete frame yet
  error?: Error;                // set iff varint header was malformed
}
```

Pure: never mutates the input, never throws (errors are returned in the result), no I/O. Wire format identical to what the Android TV v2 remote service sends on port 6466.

#### `src/main/device/androidTvRemote.ts`

`readNextFrame` deleted (40 LOC). `flushBuffer` shrinks from 11 to 12 lines and is now trivially comprehensible — single call to `parseFramedBuffer`, mirror the result onto socket state.

### Behavior parity (the safety story)

| Aspect | Before (inline) | After (`parseFramedBuffer`) |
|---|---|---|
| Wire format | varint LE, 7 bits / byte, MSB continuation | same |
| Malformed detection | `shift > 28` → destroy socket | same constant, same check |
| Malformed error message | `'Received an invalid remote protocol frame.'` | same string (so pollinator/logs unchanged) |
| Buffer clear on error | yes | yes (helper clears `remaining`; caller also defensively clears) |
| Frames decoded before bad varint | dropped (loop exits on first bad byte) | **kept** — explicit improvement; tested |
| Socket destroy | inside parser | now in caller (after parser returns error) |

The "kept frames before error" change is the only deliberate behavior delta. It's strictly safer: we now hand off any valid messages that arrived before the corrupt byte, instead of losing them. New test asserts this.

### Tests (13 new, total 156)

| Category | Cases |
|---|---|
| **Empty / trivial** | empty buffer, single 1-byte / 100-byte / 200-byte frames (single + two-byte varint headers) |
| **Multi-frame** | two back-to-back, 20-frame buffer |
| **Partial reads** | header-only, header + partial body, multi-byte varint split across reads, one-complete + one-partial |
| **Malformed input** | 6 continuation bytes → error + cleared remaining; frames before malformed varint still returned |
| **Purity** | input buffer untouched after parse; repeated calls byte-equal |
| **Realistic streaming** | full simulation: 7-byte socket chunks → all frames recovered byte-perfect |

### Validation

- typecheck (renderer + electron + backend): clean
- lint: 0 errors
- format: clean
- test: 156 / 156 (was 143; +13 from this PR)
- build: succeeds, bundle size unchanged
- Backend non-regression gates: protocol codec / cert migration / identity matching / IPC channel parity — all unchanged

### Risk

Low. The parser is pure and exhaustively tested. The only call site (`NativeRemoteClient.flushBuffer`) is a 12-line wrapper whose semantics are explicitly asserted by the new tests. If anything regresses, the 13 new tests fail before a release can ship.

### Future hooks (PR-3c onward)

- TLS socket lifecycle → `src/backend/transport/framed-tls/FramedTlsTransport.ts` behind `ITlsConnector`.
- Backpressure / drain accounting → injected `IBackpressureRecorder` port.
- A fake `TlsSocket` for tests → exercise reconnect / mid-frame disconnect / drain timeout.

Those three follow-ups complete the "transport extraction" group that started with this PR.
