### PR TITLE
[low-risk] [NO-JIRA] refactor(core): IRuntimeConfig port for env-driven flags (PR-QW-runtime)

### DIFF
--- a/src/backend/core/__tests__/runtimeConfig.test.ts
+++ b/src/backend/core/__tests__/runtimeConfig.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createNodeRuntimeConfig,
+  createRuntimeConfig,
+  getRuntimeConfig,
+  resetRuntimeConfig,
+  setRuntimeConfig,
+} from '../runtimeConfig';
+
+afterEach(() => {
+  resetRuntimeConfig();
+});
+
+describe('createNodeRuntimeConfig', () => {
+  it('GTV_UPDATER_DEV=1 → devUpdaterEnabled: true', () => {
+    expect(createNodeRuntimeConfig({ GTV_UPDATER_DEV: '1' }).devUpdaterEnabled).toBe(true);
+  });
+
+  it('GTV_UPDATER_DEV unset → false', () => {
+    expect(createNodeRuntimeConfig({}).devUpdaterEnabled).toBe(false);
+  });
+
+  it('GTV_UPDATER_DEV with any non-"1" value → false (matches existing strict check)', () => {
+    for (const value of ['0', '', 'true', 'yes', 'TRUE', ' 1 ']) {
+      expect(createNodeRuntimeConfig({ GTV_UPDATER_DEV: value }).devUpdaterEnabled).toBe(false);
+    }
+  });
+});
+
+describe('createRuntimeConfig (partial helper)', () => {
+  it('defaults devUpdaterEnabled to false', () => {
+    expect(createRuntimeConfig().devUpdaterEnabled).toBe(false);
+    expect(createRuntimeConfig({}).devUpdaterEnabled).toBe(false);
+  });
+
+  it('respects explicit overrides', () => {
+    expect(createRuntimeConfig({ devUpdaterEnabled: true }).devUpdaterEnabled).toBe(true);
+    expect(createRuntimeConfig({ devUpdaterEnabled: false }).devUpdaterEnabled).toBe(false);
+  });
+});
+
+describe('singleton accessor', () => {
+  it('setRuntimeConfig + getRuntimeConfig round-trip', () => {
+    setRuntimeConfig(createRuntimeConfig({ devUpdaterEnabled: true }));
+    expect(getRuntimeConfig().devUpdaterEnabled).toBe(true);
+    setRuntimeConfig(createRuntimeConfig({ devUpdaterEnabled: false }));
+    expect(getRuntimeConfig().devUpdaterEnabled).toBe(false);
+  });
+
+  it('resetRuntimeConfig clears the override so the next call re-reads env', () => {
+    setRuntimeConfig(createRuntimeConfig({ devUpdaterEnabled: true }));
+    expect(getRuntimeConfig().devUpdaterEnabled).toBe(true);
+    resetRuntimeConfig();
+    // After reset, getRuntimeConfig() lazily reads process.env. Whatever the
+    // real env is, the value should match createNodeRuntimeConfig(process.env).
+    expect(getRuntimeConfig()).toEqual(createNodeRuntimeConfig());
+  });
+
+  it('lazy default: getRuntimeConfig works without a prior setRuntimeConfig', () => {
+    resetRuntimeConfig();
+    const config = getRuntimeConfig();
+    expect(typeof config.devUpdaterEnabled).toBe('boolean');
+  });
+});

--- a/src/backend/core/runtimeConfig.ts
+++ b/src/backend/core/runtimeConfig.ts
@@ -1,0 +1,78 @@
+/**
+ * `IRuntimeConfig` is a tiny port that captures runtime feature flags / env
+ * overrides that production reads from `process.env` (or other ambient
+ * sources) but tests need to control deterministically.
+ *
+ * Extracted in PR-QW-runtime to retire the inline
+ * `process.env.GTV_UPDATER_DEV === '1'` read at module load time in
+ * `src/main/updater.ts`, which made it impossible to assert behavior under
+ * either dev-updater-enabled or dev-updater-disabled in a single test run.
+ *
+ * Adding a new flag: extend `IRuntimeConfig`, add a `process.env.*` read in
+ * `createNodeRuntimeConfig()`, and update the consuming module to read via
+ * `getRuntimeConfig()`. Tests can call `setRuntimeConfig(...)` to override.
+ */
+export interface IRuntimeConfig {
+  /**
+   * In development builds (`app.isPackaged === false`), the updater short-
+   * circuits to a "disabled in dev" status. Setting `GTV_UPDATER_DEV=1`
+   * bypasses that so dev builds can exercise the real GitHub release path
+   * end-to-end.
+   */
+  readonly devUpdaterEnabled: boolean;
+}
+
+/** Build a config that reads from `process.env`. Used by production wiring
+ * (see `src/main/main.ts`). Tests SHOULD NOT use this — they should pass a
+ * literal object to `setRuntimeConfig(...)` instead. */
+export function createNodeRuntimeConfig(env: NodeJS.ProcessEnv = process.env): IRuntimeConfig {
+  return {
+    devUpdaterEnabled: env.GTV_UPDATER_DEV === '1',
+  };
+}
+
+/**
+ * Build a runtime config from a partial — every missing field defaults to
+ * its "production-safe disabled" value. Useful in tests that only care about
+ * one flag. */
+export function createRuntimeConfig(partial: Partial<IRuntimeConfig> = {}): IRuntimeConfig {
+  return {
+    devUpdaterEnabled: partial.devUpdaterEnabled ?? false,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Module-level singleton accessor
+// ────────────────────────────────────────────────────────────────────────────
+//
+// `src/main/updater.ts` is currently a collection of top-level functions
+// (not a class), so we expose the config through a module-level singleton
+// with a `setRuntimeConfig(...)` setter for tests. Production wires it once
+// at startup (in `src/main/main.ts:initializeRuntime()` in a future PR; for
+// now `updater.ts` lazily defaults to `createNodeRuntimeConfig()` on first
+// access).
+//
+// Tests SHOULD call `setRuntimeConfig(createRuntimeConfig({ ... }))` in
+// `beforeEach` and `resetRuntimeConfig()` in `afterEach` to avoid leaking
+// flags across tests.
+
+let activeConfig: IRuntimeConfig | undefined;
+
+/** Lazily-initialized accessor. Defaults to reading `process.env` if no
+ * config has been installed. */
+export function getRuntimeConfig(): IRuntimeConfig {
+  activeConfig ??= createNodeRuntimeConfig();
+  return activeConfig;
+}
+
+/** Install a runtime config. Production calls this once at startup; tests
+ * call it per-test. */
+export function setRuntimeConfig(config: IRuntimeConfig): void {
+  activeConfig = config;
+}
+
+/** Drop any installed config so the next `getRuntimeConfig()` re-reads from
+ * `process.env`. Tests SHOULD call this in `afterEach`. */
+export function resetRuntimeConfig(): void {
+  activeConfig = undefined;
+}

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -6,6 +6,7 @@ import { promisify } from 'node:util';
 
 import { app, BrowserWindow, dialog, shell } from 'electron';
 
+import { getRuntimeConfig } from '../backend/core/runtimeConfig';
 import { createInitialUpdaterStatus, mergeUpdaterStatus } from '../backend/updater/updaterStatus';
 import {
   compareVersions,
@@ -43,7 +44,9 @@ const RELEASE_OWNER = 'usrivastava92';
 const RELEASE_REPO = 'gtv-desktop-remote';
 const CHECK_TIMEOUT_MS = 15_000;
 const BACKGROUND_CHECK_DEBOUNCE_MS = 15 * 60 * 1_000;
-const DEV_UPDATER_ENABLED = process.env.GTV_UPDATER_DEV === '1';
+// PR-QW-runtime: was `const DEV_UPDATER_ENABLED = process.env.GTV_UPDATER_DEV === '1';`
+// Now sourced from the runtime config port so tests can flip the flag without
+// monkey-patching process.env (which leaks across vitest workers).
 const ROLLBACK_DIR_NAME = 'rollback';
 
 let cachedRelease: ReleasePayload | undefined;
@@ -482,7 +485,7 @@ async function installMacUpdateFromZip(zipPath: string) {
 
   await logInfo('updater', 'Installing update bundle', { sourceBundle, targetBundle });
 
-  if (DEV_UPDATER_ENABLED && !app.isPackaged) {
+  if (getRuntimeConfig().devUpdaterEnabled && !app.isPackaged) {
     await logInfo('updater', 'Dev mode update install skipped', { sourceBundle, targetBundle });
     return;
   }
@@ -536,7 +539,11 @@ async function checkForMacUpdate() {
     updateInstallable: false,
   });
 
-  const updatesAllowed = app.isPackaged || DEV_UPDATER_ENABLED;
+  // PR-QW-runtime: read the flag through the runtime config port. In
+  // production this transitively reads process.env.GTV_UPDATER_DEV via
+  // createNodeRuntimeConfig(); in tests, callers install a fake config via
+  // setRuntimeConfig(createRuntimeConfig({ devUpdaterEnabled: ... })).
+  const updatesAllowed = app.isPackaged || getRuntimeConfig().devUpdaterEnabled;
 
   if (!updatesAllowed) {
     await logInfo('updater', 'Skipping updater in development mode');
@@ -690,6 +697,11 @@ export async function checkForUpdatesManually() {
 }
 
 export async function installAvailableUpdate() {
+  // PR-QW-runtime: hoist the dev-override check into a single local so the
+  // status `message` and the subsequent skip-relaunch branch stay in lockstep
+  // and the runtime config port is read exactly once per install call.
+  const installDevModeOverride = getRuntimeConfig().devUpdaterEnabled && !app.isPackaged;
+
   if (!cachedRelease || !cachedAsset || !updaterStatus.latestVersion) {
     setUpdaterStatus({
       inProgress: false,
@@ -780,13 +792,12 @@ export async function installAvailableUpdate() {
       etaSeconds: 0,
       updateAvailable: false,
       updateInstallable: false,
-      message:
-        DEV_UPDATER_ENABLED && !app.isPackaged
-          ? 'Dev mode: install step skipped.'
-          : `Update ${version} installed.`,
+      message: installDevModeOverride
+        ? 'Dev mode: install step skipped.'
+        : `Update ${version} installed.`,
     });
 
-    if (DEV_UPDATER_ENABLED && !app.isPackaged) {
+    if (installDevModeOverride) {
       await showUpdaterDialog({
         type: 'info',
         buttons: ['OK'],
@@ -899,7 +910,12 @@ export async function rollbackToPreviousVersion() {
       rollbackVersion: state.rollbackVersion,
     });
 
-    if (DEV_UPDATER_ENABLED && !app.isPackaged) {
+    // PR-QW-runtime: hoist the dev-override check into a single local so all
+    // three branch points below stay in lockstep and the runtime config port
+    // is read exactly once per rollback call.
+    const devModeOverride = getRuntimeConfig().devUpdaterEnabled && !app.isPackaged;
+
+    if (devModeOverride) {
       await logInfo('updater', 'Dev mode rollback restore skipped', {
         rollbackBundlePath,
         targetBundle,
@@ -920,13 +936,12 @@ export async function rollbackToPreviousVersion() {
       rollbackCreatedAt: undefined,
       updateAvailable: false,
       updateInstallable: false,
-      message:
-        DEV_UPDATER_ENABLED && !app.isPackaged
-          ? 'Dev mode: rollback restore skipped.'
-          : `Rolled back to ${state.rollbackVersion}.`,
+      message: devModeOverride
+        ? 'Dev mode: rollback restore skipped.'
+        : `Rolled back to ${state.rollbackVersion}.`,
     });
 
-    if (DEV_UPDATER_ENABLED && !app.isPackaged) {
+    if (devModeOverride) {
       await showUpdaterDialog({
         type: 'info',
         buttons: ['OK'],


### PR DESCRIPTION
## PR-QW-runtime — `IRuntimeConfig` port for env-driven flags

**Wave 7 / Group A — backend extraction.**

### Why

`src/main/updater.ts` read `process.env.GTV_UPDATER_DEV === '1'` at module-load time into a const, then consulted that const at 6 different call sites across 3 functions. That was:

1. **Untestable.** vitest workers share `process.env` and module evaluation runs once, so flipping the flag mid-suite was impossible.
2. **Tangled with `app.isPackaged`.** Every call site repeated `DEV_UPDATER_ENABLED && !app.isPackaged`.
3. **A 1-of-N problem.** Any future env-driven flag would duplicate the pattern.

### What changed

#### New `src/backend/core/runtimeConfig.ts`

```ts
interface IRuntimeConfig {
  readonly devUpdaterEnabled: boolean;
  // future: tracingEnabled, mockDeviceIp, ...
}

createNodeRuntimeConfig(env?): IRuntimeConfig    // production builder
createRuntimeConfig(partial?): IRuntimeConfig    // test builder, safe defaults
getRuntimeConfig() / setRuntimeConfig() / resetRuntimeConfig()
```

The accessor pattern uses a module-level lazy singleton (`activeConfig`) because `updater.ts` is a collection of top-level functions, not a class — there's no constructor to inject into. Tests call `setRuntimeConfig(createRuntimeConfig({ devUpdaterEnabled: true }))` in `beforeEach` and `resetRuntimeConfig()` in `afterEach`.

#### `src/main/updater.ts`

- Drops the module-level `const DEV_UPDATER_ENABLED`.
- 6 call sites in 3 functions now go through `getRuntimeConfig().devUpdaterEnabled`.
- Two functions (`installAvailableUpdate`, `rollbackToPreviousVersion`) hoist the combined check into a single local (`installDevModeOverride` / `devModeOverride`) so the multiple branches stay in lockstep AND the port is read exactly once per call.

### Tests (8 new, total 181)

| Test | Asserts |
|---|---|
| `GTV_UPDATER_DEV=1` parses as true | exact-match check |
| `GTV_UPDATER_DEV` unset → false | absence handled |
| Any other value (`'0'`, `'true'`, `'TRUE'`, `' 1 '`, `''`) → false | strict `=== '1'` parity preserved |
| `createRuntimeConfig()` defaults to disabled | safe-default contract |
| `createRuntimeConfig({...})` honors overrides | partial-merge contract |
| `setRuntimeConfig` + `getRuntimeConfig` round-trip | accessor contract |
| `resetRuntimeConfig` re-reads `process.env` | leak-prevention contract |
| Lazy default without prior `setRuntimeConfig` | works out of the box |

### Why this is safe

- **Behavior is byte-identical.** The only observable change is that the env read becomes lazy-on-first-access instead of evaluated at module load. The functions that consult the flag are all async, so no production code depends on the previous compile-time evaluation.
- **Strict `=== '1'` semantics preserved.** Test asserts `'true'`, `'TRUE'`, `' 1 '` all map to `false`, just like before.
- **Log lines & user-facing messages unchanged.** `'Dev mode rollback restore skipped'` / `'Dev mode: install step skipped.'` / `'Dev mode: rollback restore skipped.'` strings are byte-identical.

### Validation

- typecheck (renderer + electron + backend): clean
- lint: 0 errors
- format: clean
- test: 181 / 181 (was 173; +8 from this PR)
- build: succeeds, bundle size unchanged
- Backend non-regression gates: protocol codec / cert migration / identity matching / IPC channel parity / frame parser — all unchanged

### Future hooks

- `src/main/debug.ts` reads `process.env.GTV_REMOTE_DEBUG` + `process.argv` + `app.isPackaged` — extending `IRuntimeConfig` with `debugTelemetryEnabled` is the natural next move, but it's out of scope for this PR because it tangles with `process.argv` parsing.
- Any future flag (e.g. mock-device-ip, tracing-on, force-pairing-pin) becomes a 1-line addition to the interface + builder.

### Risk

Very low. Pure additive port + a mechanical 6-site replacement that compiles down to the same boolean check.
