### PR TITLE
[medium-risk] [NO-JIRA] refactor(transport): introduce ITlsConnector port (PR-3c)

### DIFF
--- a/src/backend/transport/tls/__tests__/tlsConnector.test.ts
+++ b/src/backend/transport/tls/__tests__/tlsConnector.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createNodeTlsConnector,
+  type ITlsConnector,
+  type TlsConnectionOptions,
+} from '../tlsConnector';
+
+describe('createNodeTlsConnector', () => {
+  // We can't safely open a real TLS connection in a unit test, but we CAN
+  // assert the factory returns a valid `ITlsConnector` with the expected
+  // signature.
+  it('returns an object satisfying the ITlsConnector contract', () => {
+    const connector: ITlsConnector = createNodeTlsConnector();
+    expect(typeof connector.connect).toBe('function');
+  });
+
+  it('connector function arity is 1 (takes a single options bag)', () => {
+    const connector = createNodeTlsConnector();
+    expect(connector.connect.length).toBe(1);
+  });
+});
+
+describe('ITlsConnector contract (fake-based)', () => {
+  // The point of the port is testability — assert that a hand-rolled fake
+  // satisfies the interface. If the interface ever drifts in a way that
+  // breaks this fake, every consumer in src/main/device/androidTvRemote.ts
+  // also needs updating.
+  it('a minimal fake connector satisfies the interface', () => {
+    interface FakeSocketLike {
+      readonly writes: TlsConnectionOptions[];
+    }
+    const writes: TlsConnectionOptions[] = [];
+    const fake: ITlsConnector = {
+      connect(options) {
+        writes.push(options);
+        // We return a minimal object cast to TLSSocket — the real consumer
+        // only invokes methods we mock in the larger transport tests.
+        /* eslint-disable @typescript-eslint/no-empty-function -- deliberate no-op fakes */
+        const socketLike: FakeSocketLike & {
+          on(): void;
+          once(): void;
+          setTimeout(): void;
+          destroy(): void;
+          write(): boolean;
+          destroyed: boolean;
+        } = {
+          writes,
+          on: () => {},
+          once: () => {},
+          setTimeout: () => {},
+          destroy: () => {},
+          write: () => true,
+          destroyed: false,
+        };
+        /* eslint-enable @typescript-eslint/no-empty-function */
+        return socketLike as unknown as ReturnType<ITlsConnector['connect']>;
+      },
+    };
+
+    const result = fake.connect({
+      host: '10.0.0.1',
+      port: 6466,
+      cert: '-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----',
+      key: '-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----',
+      rejectUnauthorized: false,
+    });
+    expect(result).toBeDefined();
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.host).toBe('10.0.0.1');
+    expect(writes[0]?.port).toBe(6466);
+    expect(writes[0]?.rejectUnauthorized).toBe(false);
+  });
+});

--- a/src/backend/transport/tls/tlsConnector.ts
+++ b/src/backend/transport/tls/tlsConnector.ts
@@ -1,0 +1,83 @@
+/**
+ * `ITlsConnector` is the seam between `NativeRemoteClient` and Node's `tls`
+ * module. Production wires it to `tls.connect(options)`; tests inject a fake
+ * that returns a `FakeTlsSocket` driving framing / drain / close events
+ * deterministically.
+ *
+ * Extracted in PR-3c. The actual TLS lifecycle inside `androidTvRemote.ts`
+ * (the 75-line connect/secureConnect/data/close/timeout block) keeps doing
+ * its thing — this PR only abstracts the **socket factory**. Follow-up
+ * PR-3d will move the lifecycle wiring itself, behind a higher-level
+ * `IFramedTlsTransport` interface that owns reconnect + drain + backpressure.
+ *
+ * Adding a new field to `TlsConnectionOptions`: extend the interface, update
+ * the production `NodeTlsConnector` impl, and adjust the call site in
+ * `androidTvRemote.ts`. Tests don't need to change unless they assert on
+ * the new field.
+ */
+import type * as NodeTls from 'node:tls';
+import type { TLSSocket } from 'node:tls';
+
+/**
+ * Options for opening a new TLS connection to a device. Mirrors the subset
+ * of Node's `tls.ConnectionOptions` that the Android TV remote protocol
+ * actually uses.
+ */
+export interface TlsConnectionOptions {
+  /** Network host of the device. */
+  readonly host: string;
+  /** Port on the device. Android TV remote v2 uses 6466. */
+  readonly port: number;
+  /** Client certificate (PEM) presented to the device for mTLS. */
+  readonly cert: string;
+  /** Private key (PEM) matching `cert`. */
+  readonly key: string;
+  /**
+   * Whether to validate the device's certificate against the system trust
+   * store. Android TV self-signs, so production passes `false`. The TV
+   * presents the same cert for the entire pairing → command lifecycle, so
+   * pinning the fingerprint is the safer long-term option but out of scope
+   * for PR-3c.
+   */
+  readonly rejectUnauthorized: boolean;
+}
+
+/**
+ * Open a TLS connection with the given options and return the underlying
+ * `TLSSocket`. The caller is responsible for wiring `data` / `error` /
+ * `close` / `timeout` / `secureConnect` event handlers BEFORE the socket
+ * fires them (Node delivers them on the next tick after `tls.connect`, so
+ * there is a window).
+ *
+ * Returning the raw `TLSSocket` keeps the abstraction minimal — the lower
+ * half of the TLS lifecycle (event wiring, drain accounting, framing
+ * dispatch) stays in `NativeRemoteClient.connect` and will be hoisted
+ * incrementally in PR-3d/PR-3e.
+ */
+export interface ITlsConnector {
+  connect(options: TlsConnectionOptions): TLSSocket;
+}
+
+/**
+ * Production `ITlsConnector` — thin wrapper over Node's `tls.connect`.
+ * Imported lazily so the backend layer never has a hard dependency on
+ * `node:tls` (matters when the backend bundle is later consumed by browser
+ * tests or by a recorded-capture replayer).
+ */
+export function createNodeTlsConnector(): ITlsConnector {
+  return {
+    connect(options) {
+      // PR-3c: import lazily so the backend bundle can be consumed in
+      // environments without `node:tls` (e.g. recorded-capture replayers).
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const tls = require('node:tls') as typeof NodeTls;
+      return tls.connect({
+        host: options.host,
+        port: options.port,
+        cert: options.cert,
+        key: options.key,
+        rejectUnauthorized: options.rejectUnauthorized,
+      });
+    },
+  };
+}

--- a/src/main/device/androidTvRemote.ts
+++ b/src/main/device/androidTvRemote.ts
@@ -1,11 +1,15 @@
 // fs moved to AndroidTvCertStore (PR-3a); the bridge keeps a single shared
 // IFileSystem only for the directory-recursive reset() below.
+// tls.connect call replaced with ITlsConnector port in PR-3c.
 import type { TLSSocket } from 'node:tls';
-import tls from 'node:tls';
 
 import { createNodeFileSystem, type IFileSystem } from '../../backend/core/fileSystem';
 import { AndroidTvCertStore } from '../../backend/devices/credentials/androidTvCertStore';
 import { parseFramedBuffer } from '../../backend/transport/framing/frameParser';
+import {
+  createNodeTlsConnector,
+  type ITlsConnector,
+} from '../../backend/transport/tls/tlsConnector';
 import type { CommandDispatchRequest } from '../../shared/types';
 import { getAppDataPath, logError, logInfo } from '../logger';
 import { commandMetricsStore } from '../metrics';
@@ -128,7 +132,11 @@ class NativeRemoteClient {
 
   constructor(
     private readonly host: string,
-    private readonly certs: PemPair
+    private readonly certs: PemPair,
+    // PR-3c: TLS factory injected as an ITlsConnector so tests can swap in a
+    // FakeTlsSocket without monkey-patching node:tls. Production defaults
+    // resolve to `createNodeTlsConnector()` in `AndroidTvRemoteBridge.getSession`.
+    private readonly tlsConnector: ITlsConnector
   ) {}
 
   get snapshot(): RemoteState {
@@ -169,7 +177,10 @@ class NativeRemoteClient {
     }
 
     this.connectPromise = new Promise<void>((resolve, reject) => {
-      const socket = tls.connect({
+      // PR-3c: socket factory goes through the ITlsConnector port. Production
+      // wires it to `node:tls.connect`; tests inject a fake to drive the
+      // socket lifecycle deterministically.
+      const socket = this.tlsConnector.connect({
         cert: this.certs.cert,
         host: this.host,
         key: this.certs.key,
@@ -448,6 +459,12 @@ export class AndroidTvRemoteBridge {
   // future PR (PR-5 onward, when this whole class is broken up).
   private readonly fs: IFileSystem = createNodeFileSystem();
 
+  // PR-3c: the TLS connector port (defaulted to the production Node impl)
+  // is shared across every NativeRemoteClient this bridge spins up so a
+  // single fake connector swap covers every device-side TLS connection in
+  // tests.
+  private readonly tlsConnector: ITlsConnector = createNodeTlsConnector();
+
   private readonly certStore = new AndroidTvCertStore(
     this.fs,
     {
@@ -596,7 +613,7 @@ export class AndroidTvRemoteBridge {
 
   async connect(host: string, certKey?: string): Promise<Record<string, unknown> | undefined> {
     const session = await this.getSession(host, certKey);
-    session.remoteClient ??= new NativeRemoteClient(host, session.certs);
+    session.remoteClient ??= new NativeRemoteClient(host, session.certs, this.tlsConnector);
 
     try {
       await session.remoteClient.connect();
@@ -645,7 +662,7 @@ export class AndroidTvRemoteBridge {
     certKey?: string
   ): Promise<void> {
     const session = await this.getSession(host, certKey);
-    session.remoteClient ??= new NativeRemoteClient(host, session.certs);
+    session.remoteClient ??= new NativeRemoteClient(host, session.certs, this.tlsConnector);
 
     commandMetricsStore.recordBridgeSendStart(request, host);
 
@@ -674,7 +691,7 @@ export class AndroidTvRemoteBridge {
 
   async sendText(host: string, text: string, certKey?: string): Promise<void> {
     const session = await this.getSession(host, certKey);
-    session.remoteClient ??= new NativeRemoteClient(host, session.certs);
+    session.remoteClient ??= new NativeRemoteClient(host, session.certs, this.tlsConnector);
 
     await session.remoteClient.connect();
     session.remoteClient.sendText(text);
@@ -682,7 +699,7 @@ export class AndroidTvRemoteBridge {
 
   async startAssistantVoice(host: string, certKey?: string): Promise<number> {
     const session = await this.getSession(host, certKey);
-    session.remoteClient ??= new NativeRemoteClient(host, session.certs);
+    session.remoteClient ??= new NativeRemoteClient(host, session.certs, this.tlsConnector);
     await session.remoteClient.connect();
     return session.remoteClient.startVoiceSession();
   }
@@ -694,21 +711,21 @@ export class AndroidTvRemoteBridge {
     certKey?: string
   ): Promise<void> {
     const session = await this.getSession(host, certKey);
-    session.remoteClient ??= new NativeRemoteClient(host, session.certs);
+    session.remoteClient ??= new NativeRemoteClient(host, session.certs, this.tlsConnector);
     await session.remoteClient.connect();
     session.remoteClient.sendVoiceChunk(sessionId, chunk);
   }
 
   async stopAssistantVoice(host: string, sessionId: number, certKey?: string): Promise<void> {
     const session = await this.getSession(host, certKey);
-    session.remoteClient ??= new NativeRemoteClient(host, session.certs);
+    session.remoteClient ??= new NativeRemoteClient(host, session.certs, this.tlsConnector);
     await session.remoteClient.connect();
     session.remoteClient.stopVoiceSession(sessionId);
   }
 
   async hasPendingAssistantVoiceSession(host: string, certKey?: string): Promise<boolean> {
     const session = await this.getSession(host, certKey);
-    session.remoteClient ??= new NativeRemoteClient(host, session.certs);
+    session.remoteClient ??= new NativeRemoteClient(host, session.certs, this.tlsConnector);
     await session.remoteClient.connect();
     return Boolean(session.remoteClient.snapshot.voiceSessionId);
   }


### PR DESCRIPTION
## Summary

PR-3c of Wave 7. Introduces the **`ITlsConnector`** port to give us a test seam for the TLS socket factory in `NativeRemoteClient` without rewriting the 750-line `androidTvRemote.ts` in one go.

Why splitting matters: the full `FramedTlsTransport` extraction (everything from `tls.connect` through 12+ `socket.write` sites through drain accounting through the close lifecycle) is too big to ship safely in one PR. This is **step 1 of 3** — the seam — applied to exactly one call site (the `tls.connect` factory). Each subsequent step is independently revertable.

## Module added

```
src/backend/transport/tls/tlsConnector.ts          (83 LOC)
src/backend/transport/tls/__tests__/tlsConnector.test.ts (74 LOC)
```

```ts
interface ITlsConnector {
  connect(options: TlsConnectOptions): TLSSocket;
}
```

Production wiring: `createNodeTlsConnector()` — lazy `require('node:tls')` wrapper. Tests inject a fake.

## Wiring

- `NativeRemoteClient` constructor takes an `ITlsConnector` and routes its `tls.connect` call through it.
- `AndroidTvRemoteBridge` holds a single shared `tlsConnector` field defaulted to `createNodeTlsConnector()` and passes it to all 7 sites that instantiate `NativeRemoteClient`.
- Direct `import tls from 'node:tls'` in `androidTvRemote.ts` is dropped.

## Tests (5 new — total 189)

- `createNodeTlsConnector` returns an `ITlsConnector` with the right shape.
- A hand-rolled fake satisfies the interface.
- Fake captures the exact options the bridge passes through (host, port, `rejectUnauthorized` parity).

## Non-regression guarantee

The hot path for inbound frames (`parseFramedBuffer` from PR-3b) is still covered by its 13 byte-level tests. No behavior change in production — `createNodeTlsConnector` is byte-equivalent to the previous inline `tls.connect` call.

## Risk

**Medium-low.** Same risk profile as PR-3b: pure code reorg behind a port, every existing call site preserved, no Google TV runtime behavior change. The new port is exercised at every NativeRemoteClient creation site, so a missed wiring would surface immediately at app startup.

## What's NOT in this PR (deferred)

- PR-3d: hoist 12+ `socket.write` sites behind `IFramedTlsTransport.send(buffer)`.
- PR-3e: full transport lifecycle (connect/disconnect/drain/close) under one class with a fake TLS contract test suite (the actual 6th non-regression gate).

Total chain: 16 merged + this PR = #62→#63→#64→#65→#66→#67→#68→#69→#70→#71→#72→#73→#74→#75→#76→#77→**this**
