### PR TITLE
[medium-risk] [NO-JIRA] refactor(transport): IFramedTlsTransport port over 9 socket.write sites (PR-3d)

### DIFF
--- a/src/backend/transport/tls/__tests__/framedTlsTransport.test.ts
+++ b/src/backend/transport/tls/__tests__/framedTlsTransport.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createFakeFramedTlsTransport,
+  createFramedTlsTransportOverSocket,
+  type IFramedTlsTransport,
+} from '../framedTlsTransport';
+
+/**
+ * PR-3d tests for the IFramedTlsTransport port. Two halves:
+ *   1. Contract tests for the production binding using a minimal fake socket.
+ *   2. Behaviour tests for the in-memory test factory itself, since other
+ *      tests in the suite will rely on it to exercise NativeRemoteClient.
+ */
+
+interface FakeSocket {
+  destroyed: boolean;
+  written: Buffer[];
+  writeReturnValue: boolean;
+  drainHandlers: (() => void)[];
+}
+
+/**
+ * Constructs a TLSSocket-shaped object minimal enough to satisfy
+ * `createFramedTlsTransportOverSocket`. Exposes a few extra hooks tests
+ * use to simulate socket-side events.
+ */
+function makeFakeSocket(): FakeSocket & {
+  write(buffer: Buffer): boolean;
+  once(event: string, handler: () => void): unknown;
+  removeListener(event: string, handler: () => void): unknown;
+  fireDrain(): void;
+} {
+  const state: FakeSocket = {
+    destroyed: false,
+    written: [],
+    writeReturnValue: true,
+    drainHandlers: [],
+  };
+  return {
+    ...state,
+    get destroyed() {
+      return state.destroyed;
+    },
+    set destroyed(value: boolean) {
+      state.destroyed = value;
+    },
+    get written() {
+      return state.written;
+    },
+    get drainHandlers() {
+      return state.drainHandlers;
+    },
+    get writeReturnValue() {
+      return state.writeReturnValue;
+    },
+    set writeReturnValue(value: boolean) {
+      state.writeReturnValue = value;
+    },
+    write(buffer: Buffer): boolean {
+      state.written.push(buffer);
+      return state.writeReturnValue;
+    },
+    once(event: string, handler: () => void) {
+      if (event === 'drain') {
+        state.drainHandlers.push(handler);
+      }
+      return this;
+    },
+    removeListener(event: string, handler: () => void) {
+      if (event === 'drain') {
+        const idx = state.drainHandlers.indexOf(handler);
+        if (idx >= 0) {
+          state.drainHandlers.splice(idx, 1);
+        }
+      }
+      return this;
+    },
+    fireDrain() {
+      const pending = state.drainHandlers.splice(0);
+      for (const h of pending) h();
+    },
+  };
+}
+
+describe('IFramedTlsTransport — production binding over socket', () => {
+  it('send() forwards the buffer to socket.write and returns its result', () => {
+    const socket = makeFakeSocket();
+    const transport = createFramedTlsTransportOverSocket(socket as never);
+    socket.writeReturnValue = true;
+    const result = transport.send(Buffer.from([1, 2, 3]));
+    expect(result).toBe(true);
+    expect(socket.written).toHaveLength(1);
+    expect(socket.written[0]?.equals(Buffer.from([1, 2, 3]))).toBe(true);
+  });
+
+  it('send() returns false when socket.write reports buffered (backpressure)', () => {
+    const socket = makeFakeSocket();
+    socket.writeReturnValue = false;
+    const transport = createFramedTlsTransportOverSocket(socket as never);
+    expect(transport.send(Buffer.from([9]))).toBe(false);
+  });
+
+  it('send() throws when the socket is already destroyed', () => {
+    const socket = makeFakeSocket();
+    socket.destroyed = true;
+    const transport = createFramedTlsTransportOverSocket(socket as never);
+    expect(() => transport.send(Buffer.from([1]))).toThrow(/closed/i);
+  });
+
+  it('destroyed mirrors socket.destroyed', () => {
+    const socket = makeFakeSocket();
+    const transport = createFramedTlsTransportOverSocket(socket as never);
+    expect(transport.destroyed).toBe(false);
+    socket.destroyed = true;
+    expect(transport.destroyed).toBe(true);
+  });
+
+  it('onDrain subscribes via socket.once and fires when drain arrives', () => {
+    const socket = makeFakeSocket();
+    const transport = createFramedTlsTransportOverSocket(socket as never);
+    const handler = vi.fn();
+    transport.onDrain(handler);
+    expect(socket.drainHandlers).toHaveLength(1);
+    socket.fireDrain();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(socket.drainHandlers).toHaveLength(0);
+  });
+
+  it('onDrain returns an unsubscribe that removes the listener', () => {
+    const socket = makeFakeSocket();
+    const transport = createFramedTlsTransportOverSocket(socket as never);
+    const handler = vi.fn();
+    const unsubscribe = transport.onDrain(handler);
+    unsubscribe();
+    expect(socket.drainHandlers).toHaveLength(0);
+    socket.fireDrain();
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe('IFramedTlsTransport — createFakeFramedTlsTransport', () => {
+  it('writes are captured in call order', () => {
+    const t = createFakeFramedTlsTransport();
+    t.send(Buffer.from([1]));
+    t.send(Buffer.from([2, 3]));
+    expect(t.writes).toHaveLength(2);
+    expect(t.writes[0]?.[0]).toBe(1);
+    expect(t.writes[1]?.[1]).toBe(3);
+  });
+
+  it('send defaults to returning true', () => {
+    const t = createFakeFramedTlsTransport();
+    expect(t.send(Buffer.from([1]))).toBe(true);
+  });
+
+  it('nextWriteReturns(false) makes exactly one write return false', () => {
+    const t = createFakeFramedTlsTransport();
+    t.nextWriteReturns(false);
+    expect(t.send(Buffer.from([1]))).toBe(false);
+    expect(t.send(Buffer.from([2]))).toBe(true); // back to default
+  });
+
+  it('emitDrain fires all pending subscribers exactly once', () => {
+    const t = createFakeFramedTlsTransport();
+    const a = vi.fn();
+    const b = vi.fn();
+    t.onDrain(a);
+    t.onDrain(b);
+    t.emitDrain();
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    t.emitDrain();
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribe before drain prevents the handler from firing', () => {
+    const t = createFakeFramedTlsTransport();
+    const a = vi.fn();
+    const unsubscribe = t.onDrain(a);
+    unsubscribe();
+    t.emitDrain();
+    expect(a).not.toHaveBeenCalled();
+  });
+
+  it('setDestroyed(true) makes subsequent send() throw', () => {
+    const t = createFakeFramedTlsTransport();
+    t.setDestroyed(true);
+    expect(t.destroyed).toBe(true);
+    expect(() => t.send(Buffer.from([1]))).toThrow(/closed/i);
+  });
+
+  it('satisfies the IFramedTlsTransport interface (compile-time gate)', () => {
+    const t: IFramedTlsTransport = createFakeFramedTlsTransport();
+    expect(t.destroyed).toBe(false);
+  });
+});

--- a/src/backend/transport/tls/framedTlsTransport.ts
+++ b/src/backend/transport/tls/framedTlsTransport.ts
@@ -1,0 +1,149 @@
+/**
+ * IFramedTlsTransport — thin port over the write+drain side of a TLS socket
+ * carrying Android TV varint-prefixed frames.
+ *
+ * PR-3d (Wave 8) introduces this port behind the same seam-first pattern
+ * PR-3c established for `ITlsConnector`. The 9 `socket.write(...)` sites
+ * scattered through `NativeRemoteClient` collapse to `transport.send(...)`,
+ * and the inline `socket.once('drain', ...)` block in `sendCommand` becomes
+ * `transport.onDrain(cb)`.
+ *
+ * What's deliberately NOT in this port (yet):
+ *   - Inbound data routing (`onData`) — still owned directly by
+ *     `NativeRemoteClient.flushBuffer` so this PR has zero risk to the
+ *     parseFramedBuffer hot path (gated by PR-3b's 13 tests).
+ *   - Socket-level event listeners (`once('remote-voice-begin')`) — those
+ *     are protocol-state plumbing on top of the parsed inbound stream, not
+ *     transport. Future PR-3e moves the inbound surface; PR-3f moves the
+ *     full lifecycle (connect / disconnect / close).
+ *
+ * Production: `createFramedTlsTransportOverSocket(socket)` wraps a live
+ * `TLSSocket` (acquired via `ITlsConnector` from PR-3c).
+ *
+ * Tests: a hand-rolled `FakeFramedTlsTransport` or the test factory at
+ * the bottom of this file (`createFakeFramedTlsTransport()`) drives
+ * `send`/`onDrain`/`destroyed` deterministically with no real socket.
+ */
+
+import type { TLSSocket } from 'node:tls';
+
+/**
+ * The transport surface used by `NativeRemoteClient` for outbound writes.
+ * Intentionally minimal — only the three things the writer cares about.
+ */
+export interface IFramedTlsTransport {
+  /**
+   * Write a single complete frame to the underlying TLS socket.
+   *
+   * Returns `true` if the bytes drained to the kernel immediately, `false`
+   * if they were buffered in userland (in which case the caller may want to
+   * `onDrain(...)` to know when the buffer empties — the metrics store
+   * uses this to log backpressure events).
+   *
+   * Throws `Error('Transport is closed')` if the underlying socket was
+   * destroyed since the transport was constructed.
+   */
+  send(frame: Buffer): boolean;
+
+  /**
+   * Subscribe to the next `'drain'` event from the underlying socket. The
+   * handler is invoked once and removed. Returns an unsubscribe function in
+   * case the caller wants to cancel the subscription before drain fires.
+   *
+   * Matching `socket.once('drain', cb)` semantics exactly so the
+   * existing call site in `NativeRemoteClient.sendCommand` is a 1:1 swap.
+   */
+  onDrain(handler: () => void): () => void;
+
+  /** Mirrors `socket.destroyed`. Used by `NativeRemoteClient.isConnected`. */
+  readonly destroyed: boolean;
+}
+
+/**
+ * Production binding — wraps a live TLSSocket. The transport doesn't own
+ * the socket's lifecycle: the caller is still responsible for `destroy()`,
+ * `connect`, listener wiring beyond drain, etc. PR-3e/PR-3f will lift
+ * those concerns into the transport when they're ready to be tested
+ * deterministically.
+ */
+export function createFramedTlsTransportOverSocket(socket: TLSSocket): IFramedTlsTransport {
+  return {
+    send(frame) {
+      if (socket.destroyed) {
+        throw new Error('Transport is closed');
+      }
+      return socket.write(frame);
+    },
+    onDrain(handler) {
+      socket.once('drain', handler);
+      return () => {
+        socket.removeListener('drain', handler);
+      };
+    },
+    get destroyed() {
+      return socket.destroyed;
+    },
+  };
+}
+
+/**
+ * Test factory — deterministic in-memory transport. Tests inspect `writes`,
+ * call `emitDrain()` to fire pending drain subscribers, and toggle
+ * `destroyed` to simulate socket close.
+ *
+ * `nextWriteReturns(value)` lets a test drive the synchronous "buffered vs.
+ * immediate" return of `send()` without touching real TCP backpressure.
+ */
+export function createFakeFramedTlsTransport(): IFramedTlsTransport & {
+  readonly writes: readonly Buffer[];
+  /** Sets the return value of the *next* `send()` call. Defaults to true. */
+  nextWriteReturns(value: boolean): void;
+  /** Fires all pending drain subscribers once, then clears them. */
+  emitDrain(): void;
+  /** Mutates `destroyed`. */
+  setDestroyed(value: boolean): void;
+} {
+  const writes: Buffer[] = [];
+  let nextReturn: boolean | undefined;
+  let isDestroyed = false;
+  const drainSubscribers: (() => void)[] = [];
+
+  return {
+    get writes(): readonly Buffer[] {
+      return writes;
+    },
+    nextWriteReturns(value) {
+      nextReturn = value;
+    },
+    emitDrain() {
+      const pending = drainSubscribers.splice(0);
+      for (const handler of pending) {
+        handler();
+      }
+    },
+    setDestroyed(value) {
+      isDestroyed = value;
+    },
+    send(frame) {
+      if (isDestroyed) {
+        throw new Error('Transport is closed');
+      }
+      writes.push(frame);
+      const result = nextReturn ?? true;
+      nextReturn = undefined;
+      return result;
+    },
+    onDrain(handler) {
+      drainSubscribers.push(handler);
+      return () => {
+        const index = drainSubscribers.indexOf(handler);
+        if (index >= 0) {
+          drainSubscribers.splice(index, 1);
+        }
+      };
+    },
+    get destroyed() {
+      return isDestroyed;
+    },
+  };
+}

--- a/src/main/device/androidTvRemote.ts
+++ b/src/main/device/androidTvRemote.ts
@@ -7,6 +7,10 @@ import { createNodeFileSystem, type IFileSystem } from '../../backend/core/fileS
 import { AndroidTvCertStore } from '../../backend/devices/credentials/androidTvCertStore';
 import { parseFramedBuffer } from '../../backend/transport/framing/frameParser';
 import {
+  createFramedTlsTransportOverSocket,
+  type IFramedTlsTransport,
+} from '../../backend/transport/tls/framedTlsTransport';
+import {
   createNodeTlsConnector,
   type ITlsConnector,
 } from '../../backend/transport/tls/tlsConnector';
@@ -115,6 +119,15 @@ function normalizeRemoteError(error: unknown, fallback: string): Error {
 
 class NativeRemoteClient {
   private socket: TLSSocket | undefined;
+
+  // PR-3d: framed transport wraps the write+drain side of the socket. Created
+  // alongside `this.socket` at the end of connect() (after the TLSSocket is
+  // ready) and torn down in disconnect(). All outbound writes go through
+  // `this.transport.send(...)`; the inline `socket.once('drain')` block
+  // becomes `this.transport.onDrain(...)`. The inbound side (data/close
+  // listeners + flushBuffer) intentionally stays on the socket directly for
+  // this PR — PR-3e moves it.
+  private transport: IFramedTlsTransport | undefined;
 
   private connectPromise: Promise<void> | undefined;
 
@@ -239,6 +252,9 @@ class NativeRemoteClient {
 
       socket.once('remote-protocol-ready', finishProtocolHandshake);
       this.socket = socket;
+      // PR-3d: wrap the live socket in the framed transport port now that it
+      // exists. Every send/drain call from here on goes through the port.
+      this.transport = createFramedTlsTransportOverSocket(socket);
     }).finally(() => {
       this.connectPromise = undefined;
     });
@@ -265,19 +281,26 @@ class NativeRemoteClient {
     this.socket.destroy();
     commandMetricsStore.recordSocketClosed(this.host);
     this.socket = undefined;
+    // PR-3d: tear down the transport alongside the socket so any stray
+    // `transport.send` after disconnect throws cleanly rather than writing
+    // to a destroyed socket.
+    this.transport = undefined;
     this.protocolReady = false;
     this.buffer = Buffer.alloc(0);
   }
 
   sendCommand(request: CommandDispatchRequest): void {
-    const socket = this.getSocket();
-    const wroteImmediately = socket.write(createRemoteKeyInject(request.command));
+    // PR-3d: routed through IFramedTlsTransport. send() returns the same
+    // `wroteImmediately` boolean that socket.write did, and onDrain() has
+    // identical semantics to `socket.once('drain', ...)`.
+    const transport = this.getTransport();
+    const wroteImmediately = transport.send(createRemoteKeyInject(request.command));
     commandMetricsStore.recordSocketWrite(request, {
       host: this.host,
       buffered: !wroteImmediately,
     });
     if (!wroteImmediately) {
-      socket.once('drain', () => {
+      transport.onDrain(() => {
         commandMetricsStore.recordSocketDrain(this.host, request.id);
       });
     }
@@ -289,17 +312,22 @@ class NativeRemoteClient {
       throw new Error('Text cannot be empty.');
     }
 
-    const socket = this.getSocket();
-    socket.write(
+    // PR-3d
+    this.getTransport().send(
       createImeBatchEditMessage(this.state.imeCounter, this.state.imeFieldCounter, value)
     );
   }
 
   async startVoiceSession(): Promise<number> {
+    // PR-3d: writes go through the transport port; the
+    // `socket.once('remote-voice-begin')` event listener stays on the raw
+    // socket because that event is protocol-state plumbing on top of the
+    // parsed inbound stream, not a transport-level concern. PR-3e moves it.
     const socket = this.getSocket();
+    const transport = this.getTransport();
     if (this.state.voiceSessionId) {
       const existingSessionId = this.state.voiceSessionId;
-      socket.write(createRemoteVoiceBegin(existingSessionId));
+      transport.send(createRemoteVoiceBegin(existingSessionId));
       return existingSessionId;
     }
 
@@ -319,17 +347,17 @@ class NativeRemoteClient {
         socket.once('remote-voice-begin', onVoiceBegin);
       });
 
-    socket.write(createRemoteKeyInjectRaw('KEYCODE_SEARCH', 'START_LONG'));
+    transport.send(createRemoteKeyInjectRaw('KEYCODE_SEARCH', 'START_LONG'));
 
     let sessionId: number;
     try {
       sessionId = await waitForVoiceBegin();
     } catch {
-      socket.write(createRemoteKeyInjectRaw('KEYCODE_SEARCH', 'SHORT'));
+      transport.send(createRemoteKeyInjectRaw('KEYCODE_SEARCH', 'SHORT'));
       sessionId = await waitForVoiceBegin();
     }
 
-    socket.write(createRemoteVoiceBegin(sessionId));
+    transport.send(createRemoteVoiceBegin(sessionId));
     return sessionId;
   }
 
@@ -338,14 +366,15 @@ class NativeRemoteClient {
       return;
     }
 
-    const socket = this.getSocket();
-    socket.write(createRemoteVoicePayload(sessionId, samples));
+    // PR-3d
+    this.getTransport().send(createRemoteVoicePayload(sessionId, samples));
   }
 
   stopVoiceSession(sessionId: number): void {
-    const socket = this.getSocket();
-    socket.write(createRemoteVoiceEnd(sessionId));
-    socket.write(createRemoteKeyInjectRaw('KEYCODE_SEARCH', 'END_LONG'));
+    // PR-3d
+    const transport = this.getTransport();
+    transport.send(createRemoteVoiceEnd(sessionId));
+    transport.send(createRemoteKeyInjectRaw('KEYCODE_SEARCH', 'END_LONG'));
     if (this.state.voiceSessionId === sessionId) {
       this.state.voiceSessionId = undefined;
     }
@@ -357,6 +386,19 @@ class NativeRemoteClient {
     }
 
     return this.socket;
+  }
+
+  /**
+   * PR-3d: like `getSocket()` but returns the framed transport port.
+   * Throws the same "Connection has been lost." error so the existing
+   * error-handling behavior at call sites stays identical.
+   */
+  private getTransport(): IFramedTlsTransport {
+    if (!this.transport || this.transport.destroyed) {
+      throw new Error('Connection has been lost.');
+    }
+
+    return this.transport;
   }
 
   /**


### PR DESCRIPTION
## Summary

PR-3d of Wave 8. Introduces the **`IFramedTlsTransport`** port that owns the **write + drain** side of `NativeRemoteClient`'s TLS socket. All 9 `socket.write(...)` call sites now flow through `transport.send(...)`; the inline `socket.once('drain', ...)` in `sendCommand` becomes `transport.onDrain(...)`. Same seam-first pattern PR-3c (ITlsConnector) established.

## Module added

```
src/backend/transport/tls/framedTlsTransport.ts          (135 LOC)
src/backend/transport/tls/__tests__/framedTlsTransport.test.ts (198 LOC, 13 tests)
```

Port shape (intentionally tiny — only the 3 things the writer cares about):

```ts
interface IFramedTlsTransport {
  send(frame: Buffer): boolean;
  onDrain(handler: () => void): () => void;
  readonly destroyed: boolean;
}
```

Implementations:
- `createFramedTlsTransportOverSocket(socket)` — production binding wrapping a live `TLSSocket`.
- `createFakeFramedTlsTransport()` — in-memory test factory with `.writes` (captured array), `.nextWriteReturns(boolean)`, `.emitDrain()`, `.setDestroyed(boolean)`.

## Wiring in `NativeRemoteClient`

- New field `transport: IFramedTlsTransport | undefined` next to `socket`.
- New private `getTransport()` helper mirroring `getSocket()` exactly (throws `"Connection has been lost."` if destroyed).
- Transport is constructed at the end of `connect()` (after `secureConnect`) and cleared in `disconnect()`.
- **All 9 `socket.write(...)` sites migrated** to `transport.send(...)`:
  - `sendCommand`: 1 site + 1 drain handler
  - `sendText`: 1 site
  - `startVoiceSession`: 4 sites
  - `sendVoiceChunk`: 1 site
  - `stopVoiceSession`: 2 sites

Verification: `grep -E "^\\s*socket\\.write" src/main/device/androidTvRemote.ts` returns **zero** matches after this PR.

## What deliberately stays on socket directly

PR-3e is the next step — these get moved in a separate PR so the diff stays reviewable:

- `socket.on('data')` → `flushBuffer` → `parseFramedBuffer` (PR-3b hot path, 13 tests)
- `socket.once('remote-voice-begin')` — protocol-state event, not transport
- `socket.on('close')`, `socket.on('error')`, `socket.on('timeout')` — lifecycle wiring stays until PR-3f.

## Tests (13 new — total 209 → 222)

**Production binding (over fake socket):**
1. `send()` forwards the buffer and returns socket.write's result.
2. `send()` returns false when socket reports buffered backpressure.
3. `send()` throws when the socket is already destroyed.
4. `destroyed` mirrors `socket.destroyed`.
5. `onDrain` subscribes via `socket.once` and fires once.
6. `onDrain` unsubscribe removes the listener.

**Fake transport (the test factory itself):**
7. Writes captured in call order.
8. `send` defaults to returning true.
9. `nextWriteReturns(false)` affects exactly one call.
10. `emitDrain` fires all pending subscribers once.
11. Unsubscribe before drain prevents firing.
12. `setDestroyed(true)` makes next `send()` throw.
13. Compile-time gate that the fake satisfies `IFramedTlsTransport`.

## Risk

**Medium.** The 9 send-site migrations are 1:1 — `send()` returns the same `boolean` `socket.write` returned, and `onDrain()` has identical semantics to `socket.once('drain', cb)`. The new port is exercised at every send site, so a missed wiring would surface at the first remote command, not silently.

Non-regression guarantee: PR-3b's `parseFramedBuffer` hot path (13 byte-level tests) is unchanged; the inbound side of the socket is untouched in this PR.

Total chain: 18 merged + #79 + #80 + this = **21** in flight from the original baseline.
