### PR TITLE
[low-risk] [NO-JIRA] refactor(voice): unify VoiceSessionService on shared ILogger + IClock (PR-QW-adopt-logger)

### DIFF
--- a/src/backend/voice/VoiceSessionService.ts
+++ b/src/backend/voice/VoiceSessionService.ts
@@ -12,7 +12,16 @@
  * The service deliberately does NOT know about `SavedDevice` or `host`.
  * The caller passes a `VoiceSessionTarget` per call; the service decides
  * everything else (session id ownership, stats lifecycle, log cadence).
+ *
+ * PR-QW-adopt-logger (Wave 9): the previously-local `IVoiceLogger` and
+ * `IClock` interfaces are replaced by the shared `ILogger` (PR-QW-logger)
+ * and `IClock` (PR-QW-clock) ports. Removes 2 duplicate interface
+ * declarations and lets callers pass `silentLogger` /
+ * `createInMemoryLogger()` directly without an adapter.
  */
+import type { IClock } from '../core/clock';
+import type { ILogger } from '../core/logger';
+
 export interface VoiceSessionTarget {
   /** Stable id of the device the caller has resolved (used in log details). */
   deviceId: string;
@@ -34,16 +43,6 @@ export interface IVoiceTransport {
   hasPending(host: string, macAddress?: string): Promise<boolean>;
 }
 
-/** Minimal clock port — only `now()` is needed for stats and durations. */
-export interface IClock {
-  now(): number;
-}
-
-/** Minimal logger port. Mirrors the shape of `src/main/logger.ts:logInfo`. */
-export interface IVoiceLogger {
-  info(scope: string, message: string, details?: Record<string, unknown>): Promise<void>;
-}
-
 interface SessionStats {
   chunks: number;
   bytes: number;
@@ -60,14 +59,15 @@ export class VoiceSessionService {
   constructor(
     private readonly transport: IVoiceTransport,
     private readonly clock: IClock,
-    private readonly logger: IVoiceLogger
+    private readonly logger: ILogger
   ) {}
 
   /** Begin a voice session for the given device. Returns the transport's
    * session id, which the caller must echo back on chunk / stop. */
   async start(target: VoiceSessionTarget): Promise<number> {
     const sessionId = await this.transport.start(target.host, target.macAddress);
-    await this.logger.info('adapter', 'Assistant voice session started', {
+    // PR-QW-adopt-logger: ILogger is synchronous-by-contract — no await.
+    this.logger.info('adapter', 'Assistant voice session started', {
       deviceId: target.deviceId,
       host: target.host,
       sessionId,
@@ -98,7 +98,7 @@ export class VoiceSessionService {
       stats.chunks += 1;
       stats.bytes += chunk.length;
       if (stats.chunks % VOICE_PROGRESS_LOG_EVERY_N_CHUNKS === 0) {
-        await this.logger.info('adapter', 'Assistant voice chunk progress', {
+        this.logger.info('adapter', 'Assistant voice chunk progress', {
           deviceId: target.deviceId,
           host: target.host,
           sessionId,
@@ -107,7 +107,7 @@ export class VoiceSessionService {
         });
       }
     } else {
-      await this.logger.info('adapter', 'Assistant voice chunk sent without tracked session', {
+      this.logger.info('adapter', 'Assistant voice chunk sent without tracked session', {
         deviceId: target.deviceId,
         host: target.host,
         sessionId,
@@ -121,7 +121,7 @@ export class VoiceSessionService {
     await this.transport.stop(target.host, sessionId, target.macAddress);
     const stats = this.stats.get(sessionId);
     this.stats.delete(sessionId);
-    await this.logger.info('adapter', 'Assistant voice session ended', {
+    this.logger.info('adapter', 'Assistant voice session ended', {
       deviceId: target.deviceId,
       host: target.host,
       sessionId,

--- a/src/backend/voice/__tests__/VoiceSessionService.test.ts
+++ b/src/backend/voice/__tests__/VoiceSessionService.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
+import type { IClock } from '../../core/clock';
+import type { ILogger } from '../../core/logger';
 import {
   VOICE_PROGRESS_LOG_EVERY_N_CHUNKS,
   VoiceSessionService,
-  type IClock,
-  type IVoiceLogger,
   type IVoiceTransport,
   type VoiceSessionTarget,
 } from '../VoiceSessionService';
@@ -59,14 +59,26 @@ function makeFakes(opts: { startSessionId?: number; pending?: boolean } = {}) {
     },
   };
 
+  // PR-QW-adopt-logger: shared IClock from core/clock requires `nowDate()`
+  // too. Inline both methods rather than importing createFakeClock so the
+  // test stays self-contained (and explicit about how time advances).
   const clock: IClock = {
     now: () => timeNow,
+    nowDate: () => new Date(timeNow),
   };
 
-  const logger: IVoiceLogger = {
+  // PR-QW-adopt-logger: shared ILogger has 3 levels and is synchronous.
+  // Tests still only care about info(), but warn/error are needed to
+  // satisfy the interface.
+  const logger: ILogger = {
     info: (scope, message, details) => {
-      logs.push({ scope, message, details });
-      return Promise.resolve();
+      logs.push({ scope, message, details: details as Record<string, unknown> | undefined });
+    },
+    warn: () => {
+      /* unused */
+    },
+    error: () => {
+      /* unused */
     },
   };
 

--- a/src/main/device/googleTvAdapter.ts
+++ b/src/main/device/googleTvAdapter.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import { app } from 'electron';
 
+import { createSystemClock } from '../../backend/core/clock';
 import { VoiceSessionService } from '../../backend/voice/VoiceSessionService';
 import type {
   BootstrapState,
@@ -16,7 +17,7 @@ import type {
   PairingRequest,
   SavedDevice,
 } from '../../shared/types';
-import { getAppDataPath, logError, logInfo } from '../logger';
+import { createNodeLogger, getAppDataPath, logError, logInfo } from '../logger';
 import { commandMetricsStore } from '../metrics';
 
 import { androidTvRemoteBridge } from './androidTvRemote';
@@ -47,6 +48,11 @@ export class GoogleTvAdapter implements DeviceAdapter {
   private readonly voiceSessions: VoiceSessionService;
 
   constructor(voiceSessions?: VoiceSessionService) {
+    // PR-QW-adopt-logger (Wave 9): swap the inline ad-hoc clock + logger
+    // adapters for the canonical createSystemClock() and createNodeLogger()
+    // factories. Removes two micro-implementations that were already drifting
+    // (the clock missed `nowDate`; the logger faked the sync contract by
+    // accident).
     this.voiceSessions =
       voiceSessions ??
       new VoiceSessionService(
@@ -59,8 +65,8 @@ export class GoogleTvAdapter implements DeviceAdapter {
           hasPending: (host, macAddress) =>
             androidTvRemoteBridge.hasPendingAssistantVoiceSession(host, macAddress),
         },
-        { now: () => Date.now() },
-        { info: (scope, message, details) => logInfo(scope, message, details) }
+        createSystemClock(),
+        createNodeLogger()
       );
   }
 


### PR DESCRIPTION
## Summary

PR-QW-adopt-logger of Wave 9. Retires the two duplicate port interfaces (`IClock`, `IVoiceLogger`) in `VoiceSessionService` and adopts the canonical shared ports from `core/clock` (PR-QW-clock) and `core/logger` (PR-QW-logger).

## What was duplicated

`VoiceSessionService.ts` shipped in PR-5b with its own local copies because the shared `core/` ports didn't exist yet:

```ts
// REMOVED
export interface IClock { now(): number; }
export interface IVoiceLogger {
  info(scope: string, message: string, details?: Record<string, unknown>): Promise<void>;
}
```

Both are now imported from the shared ports:

```ts
// NEW
import type { IClock } from '../core/clock';      // has now() + nowDate()
import type { ILogger } from '../core/logger';    // sync, 3 levels (info/warn/error)
```

## VoiceSessionService changes

- Drop the two local interfaces.
- Constructor types updated to the shared ports.
- Drop 4 unnecessary `await`s on `this.logger.info(...)` — `ILogger` has been synchronous-by-contract since the PR-QW-logger revision.

## GoogleTvAdapter cleanup (the surprise win)

The adapter was constructing `VoiceSessionService` with two ad-hoc inline implementations that were already drifting from the canonical ports:

```ts
// BEFORE
new VoiceSessionService(
  transport,
  { now: () => Date.now() },                                  // missed nowDate()
  { info: (s, m, d) => logInfo(s, m, d) }                     // returned Promise — fake sync
);

// AFTER
new VoiceSessionService(transport, createSystemClock(), createNodeLogger());
```

The typecheck error this PR surfaced (`Property 'nowDate' is missing`) was a real latent bug — the ad-hoc clock would have broken any future call site that needed a `Date`.

## Tests

The 8 existing voice tests continue to pass (no semantic change). Fakes updated to:
- Add `nowDate()` to the test clock (literally `() => new Date(timeNow)`).
- Add stub `warn`/`error` to satisfy the shared 3-level `ILogger`.

## Risk

**Low.** Pure de-duplication. Behavior identical — same log lines fire, same clock reads return the same numbers. Same risk profile as previous QW PRs.

## What's NOT in this PR

This was originally pitched as "migrate 5 backend modules from `main/logger` to `ILogger`". Investigation showed only **one** backend file imported logger directly (this one), so the scope shrank from "5 migrations" to "1 unification + 1 caller cleanup". Backend layering is healthier than expected — most of the 22 imports the original pitch counted live in `src/main/`, which is the right boundary for direct `logInfo` usage.

Total chain: 21 merged + this PR = #62 → ... → #81 → **this**
