### PR TITLE
[medium-risk] [NO-JIRA] refactor(transport): IFramedTlsTransport.onError/onClose/onTimeout (PR-3f)

### DIFF
--- a/src/backend/transport/tls/__tests__/framedTlsTransport.test.ts
+++ b/src/backend/transport/tls/__tests__/framedTlsTransport.test.ts
@@ -20,6 +20,10 @@ interface FakeSocket {
   drainHandlers: (() => void)[];
   // PR-3e: track data listeners for onData test coverage.
   dataHandlers: ((chunk: Buffer | string) => void)[];
+  // PR-3f: track lifecycle listeners.
+  errorHandlers: ((error: Error) => void)[];
+  closeHandlers: (() => void)[];
+  timeoutHandlers: (() => void)[];
 }
 
 /**
@@ -29,11 +33,14 @@ interface FakeSocket {
  */
 function makeFakeSocket(): FakeSocket & {
   write(buffer: Buffer): boolean;
-  on(event: string, handler: (chunk?: Buffer | string) => void): unknown;
+  on(event: string, handler: (...args: unknown[]) => void): unknown;
   once(event: string, handler: () => void): unknown;
-  removeListener(event: string, handler: () => void): unknown;
+  removeListener(event: string, handler: (...args: unknown[]) => void): unknown;
   fireDrain(): void;
   fireData(chunk: Buffer | string): void;
+  fireError(error: Error): void;
+  fireClose(): void;
+  fireTimeout(): void;
 } {
   const state: FakeSocket = {
     destroyed: false,
@@ -41,6 +48,9 @@ function makeFakeSocket(): FakeSocket & {
     writeReturnValue: true,
     drainHandlers: [],
     dataHandlers: [],
+    errorHandlers: [],
+    closeHandlers: [],
+    timeoutHandlers: [],
   };
   return {
     ...state,
@@ -69,11 +79,25 @@ function makeFakeSocket(): FakeSocket & {
       state.written.push(buffer);
       return state.writeReturnValue;
     },
-    on(event: string, handler: (chunk: Buffer | string) => void) {
-      // PR-3e: only the 'data' event is supported here — that's all
-      // createFramedTlsTransportOverSocket calls into.
-      if (event === 'data') {
-        state.dataHandlers.push(handler);
+    on(event: string, handler: (...args: unknown[]) => void) {
+      // PR-3f: extended to support data + error + close + timeout. Each
+      // event has its own handler list so the production binding can be
+      // verified per-event.
+      // PR-3f: bivariant function types allow `(...args: unknown[]) => void`
+      // to be assigned to each specific handler signature without a cast.
+      switch (event) {
+        case 'data':
+          state.dataHandlers.push(handler);
+          break;
+        case 'error':
+          state.errorHandlers.push(handler);
+          break;
+        case 'close':
+          state.closeHandlers.push(handler);
+          break;
+        case 'timeout':
+          state.timeoutHandlers.push(handler);
+          break;
       }
       return this;
     },
@@ -83,18 +107,24 @@ function makeFakeSocket(): FakeSocket & {
       }
       return this;
     },
-    removeListener(event: string, handler: () => void) {
-      if (event === 'drain') {
-        const idx = state.drainHandlers.indexOf(handler);
+    removeListener(event: string, handler: (...args: unknown[]) => void) {
+      // PR-3f: per-event splice. Bivariant comparison is fine here — we're
+      // only doing reference equality on the handler.
+      const map: Record<
+        string,
+        { indexOf(h: unknown): number; splice(i: number, n: number): void }
+      > = {
+        drain: state.drainHandlers,
+        data: state.dataHandlers,
+        error: state.errorHandlers,
+        close: state.closeHandlers,
+        timeout: state.timeoutHandlers,
+      };
+      const target = map[event];
+      if (target) {
+        const idx = target.indexOf(handler);
         if (idx >= 0) {
-          state.drainHandlers.splice(idx, 1);
-        }
-      } else if (event === 'data') {
-        // PR-3e: TS allows `(chunk) => void` to be compared against
-        // `() => void` here via bivariance — no cast needed at all.
-        const idx = state.dataHandlers.indexOf(handler);
-        if (idx >= 0) {
-          state.dataHandlers.splice(idx, 1);
+          target.splice(idx, 1);
         }
       }
       return this;
@@ -106,6 +136,21 @@ function makeFakeSocket(): FakeSocket & {
     fireData(chunk: Buffer | string) {
       for (const h of state.dataHandlers.slice()) {
         h(chunk);
+      }
+    },
+    fireError(error: Error) {
+      for (const h of state.errorHandlers.slice()) {
+        h(error);
+      }
+    },
+    fireClose() {
+      for (const h of state.closeHandlers.slice()) {
+        h();
+      }
+    },
+    fireTimeout() {
+      for (const h of state.timeoutHandlers.slice()) {
+        h();
       }
     },
   };
@@ -196,6 +241,60 @@ describe('IFramedTlsTransport — production binding over socket', () => {
     socket.fireData(Buffer.from([1]));
     expect(handler).not.toHaveBeenCalled();
   });
+
+  it('onError subscribes via socket.on(error) and dispatches the error', () => {
+    const socket = makeFakeSocket();
+    const transport = createFramedTlsTransportOverSocket(socket as never);
+    const handler = vi.fn();
+    transport.onError(handler);
+    expect(socket.errorHandlers).toHaveLength(1);
+    socket.fireError(new Error('boom'));
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect((handler.mock.calls[0]?.[0] as Error).message).toBe('boom');
+  });
+
+  it('onClose subscribes via socket.on(close) and dispatches with no payload', () => {
+    const socket = makeFakeSocket();
+    const transport = createFramedTlsTransportOverSocket(socket as never);
+    const handler = vi.fn();
+    transport.onClose(handler);
+    expect(socket.closeHandlers).toHaveLength(1);
+    socket.fireClose();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('onTimeout subscribes via socket.on(timeout) and dispatches with no payload', () => {
+    const socket = makeFakeSocket();
+    const transport = createFramedTlsTransportOverSocket(socket as never);
+    const handler = vi.fn();
+    transport.onTimeout(handler);
+    expect(socket.timeoutHandlers).toHaveLength(1);
+    socket.fireTimeout();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('lifecycle unsubscribes remove their respective listeners', () => {
+    const socket = makeFakeSocket();
+    const transport = createFramedTlsTransportOverSocket(socket as never);
+    const errH = vi.fn();
+    const closeH = vi.fn();
+    const timeoutH = vi.fn();
+    const unErr = transport.onError(errH);
+    const unClose = transport.onClose(closeH);
+    const unTime = transport.onTimeout(timeoutH);
+    unErr();
+    unClose();
+    unTime();
+    expect(socket.errorHandlers).toHaveLength(0);
+    expect(socket.closeHandlers).toHaveLength(0);
+    expect(socket.timeoutHandlers).toHaveLength(0);
+    socket.fireError(new Error('x'));
+    socket.fireClose();
+    socket.fireTimeout();
+    expect(errH).not.toHaveBeenCalled();
+    expect(closeH).not.toHaveBeenCalled();
+    expect(timeoutH).not.toHaveBeenCalled();
+  });
 });
 
 describe('IFramedTlsTransport — createFakeFramedTlsTransport', () => {
@@ -281,5 +380,37 @@ describe('IFramedTlsTransport — createFakeFramedTlsTransport', () => {
     expect(() => {
       t.emitData(Buffer.from([0xff]));
     }).not.toThrow();
+  });
+
+  it('emitError/emitClose/emitTimeout dispatch to their respective subscribers', () => {
+    const t = createFakeFramedTlsTransport();
+    const errH = vi.fn();
+    const closeH = vi.fn();
+    const timeoutH = vi.fn();
+    t.onError(errH);
+    t.onClose(closeH);
+    t.onTimeout(timeoutH);
+    t.emitError(new Error('boom'));
+    t.emitClose();
+    t.emitTimeout();
+    expect(errH).toHaveBeenCalledWith(new Error('boom'));
+    expect(closeH).toHaveBeenCalledTimes(1);
+    expect(timeoutH).toHaveBeenCalledTimes(1);
+  });
+
+  it('lifecycle unsubscribes stop further fake dispatches', () => {
+    const t = createFakeFramedTlsTransport();
+    const errH = vi.fn();
+    const closeH = vi.fn();
+    const timeoutH = vi.fn();
+    t.onError(errH)();
+    t.onClose(closeH)();
+    t.onTimeout(timeoutH)();
+    t.emitError(new Error('x'));
+    t.emitClose();
+    t.emitTimeout();
+    expect(errH).not.toHaveBeenCalled();
+    expect(closeH).not.toHaveBeenCalled();
+    expect(timeoutH).not.toHaveBeenCalled();
   });
 });

--- a/src/backend/transport/tls/framedTlsTransport.ts
+++ b/src/backend/transport/tls/framedTlsTransport.ts
@@ -76,6 +76,30 @@ export interface IFramedTlsTransport {
    */
   onData(handler: (chunk: Buffer) => void): () => void;
 
+  /**
+   * Subscribe to fatal socket errors. Mirrors `socket.on('error', cb)` —
+   * fires zero or more times before close. Returns an unsubscribe.
+   * PR-3f completion of the lifecycle side of the transport contract.
+   */
+  onError(handler: (error: Error) => void): () => void;
+
+  /**
+   * Subscribe to socket close events. Fires exactly once after the socket
+   * is destroyed (whether by remote disconnect, fatal error, or local
+   * `disconnect()`). Returns an unsubscribe.
+   */
+  onClose(handler: () => void): () => void;
+
+  /**
+   * Subscribe to socket timeout events. The underlying socket's idle
+   * timeout was configured via `socket.setTimeout(ms)` before this
+   * transport was created — the transport intentionally does NOT own
+   * timeout configuration since the value depends on the caller's
+   * protocol (e.g. REMOTE_CONNECT_TIMEOUT_MS for the connect handshake).
+   * Returns an unsubscribe.
+   */
+  onTimeout(handler: () => void): () => void;
+
   /** Mirrors `socket.destroyed`. Used by `NativeRemoteClient.isConnected`. */
   readonly destroyed: boolean;
 }
@@ -113,6 +137,24 @@ export function createFramedTlsTransportOverSocket(socket: TLSSocket): IFramedTl
         socket.removeListener('data', listener);
       };
     },
+    onError(handler) {
+      socket.on('error', handler);
+      return () => {
+        socket.removeListener('error', handler);
+      };
+    },
+    onClose(handler) {
+      socket.on('close', handler);
+      return () => {
+        socket.removeListener('close', handler);
+      };
+    },
+    onTimeout(handler) {
+      socket.on('timeout', handler);
+      return () => {
+        socket.removeListener('timeout', handler);
+      };
+    },
     get destroyed() {
       return socket.destroyed;
     },
@@ -140,6 +182,12 @@ export function createFakeFramedTlsTransport(): IFramedTlsTransport & {
    * subscribe via separate transports.
    */
   emitData(chunk: Buffer): void;
+  /** PR-3f: trigger every active onError subscriber with `error`. */
+  emitError(error: Error): void;
+  /** PR-3f: trigger every active onClose subscriber. */
+  emitClose(): void;
+  /** PR-3f: trigger every active onTimeout subscriber. */
+  emitTimeout(): void;
   /** Mutates `destroyed`. */
   setDestroyed(value: boolean): void;
 } {
@@ -151,6 +199,10 @@ export function createFakeFramedTlsTransport(): IFramedTlsTransport & {
   // factory can verify multi-subscriber dispatch the same way the
   // production binding does.
   const dataSubscribers: ((chunk: Buffer) => void)[] = [];
+  // PR-3f: lifecycle subscribers.
+  const errorSubscribers: ((error: Error) => void)[] = [];
+  const closeSubscribers: (() => void)[] = [];
+  const timeoutSubscribers: (() => void)[] = [];
 
   return {
     get writes(): readonly Buffer[] {
@@ -168,6 +220,21 @@ export function createFakeFramedTlsTransport(): IFramedTlsTransport & {
     emitData(chunk) {
       for (const handler of dataSubscribers.slice()) {
         handler(chunk);
+      }
+    },
+    emitError(error) {
+      for (const handler of errorSubscribers.slice()) {
+        handler(error);
+      }
+    },
+    emitClose() {
+      for (const handler of closeSubscribers.slice()) {
+        handler();
+      }
+    },
+    emitTimeout() {
+      for (const handler of timeoutSubscribers.slice()) {
+        handler();
       }
     },
     setDestroyed(value) {
@@ -197,6 +264,33 @@ export function createFakeFramedTlsTransport(): IFramedTlsTransport & {
         const index = dataSubscribers.indexOf(handler);
         if (index >= 0) {
           dataSubscribers.splice(index, 1);
+        }
+      };
+    },
+    onError(handler) {
+      errorSubscribers.push(handler);
+      return () => {
+        const index = errorSubscribers.indexOf(handler);
+        if (index >= 0) {
+          errorSubscribers.splice(index, 1);
+        }
+      };
+    },
+    onClose(handler) {
+      closeSubscribers.push(handler);
+      return () => {
+        const index = closeSubscribers.indexOf(handler);
+        if (index >= 0) {
+          closeSubscribers.splice(index, 1);
+        }
+      };
+    },
+    onTimeout(handler) {
+      timeoutSubscribers.push(handler);
+      return () => {
+        const index = timeoutSubscribers.indexOf(handler);
+        if (index >= 0) {
+          timeoutSubscribers.splice(index, 1);
         }
       };
     },

--- a/src/main/device/androidTvRemote.ts
+++ b/src/main/device/androidTvRemote.ts
@@ -212,29 +212,35 @@ class NativeRemoteClient {
         void logError('androidtvremote', 'Remote socket error', normalized);
       };
 
+      // PR-3f: socket.setTimeout still owns the timeout VALUE (the transport
+      // intentionally doesn't take ownership of timeout configuration since
+      // the value is protocol-specific). The transport.onTimeout subscription
+      // below replaces the prior socket.on('timeout') listener.
       socket.setTimeout(REMOTE_CONNECT_TIMEOUT_MS);
-      socket.on('timeout', () => {
+      // PR-3f: ALL lifecycle handlers below now flow through IFramedTlsTransport
+      // (onTimeout / onError / onClose) and behavior-only handlers stay inline.
+      // Captured as named arrows so they can be attached after we construct
+      // the transport at the end of this block.
+      const onSocketTimeout = (): void => {
         socket.destroy(new Error('Remote connection timed out.'));
-      });
-      socket.on('secureConnect', () => {
+      };
+      const onSecureConnect = (): void => {
+        // secureConnect is NOT a transport-level event (it's TLS handshake
+        // completion). It stays a raw socket listener.
         this.state.lastActivityAt = Date.now();
-      });
-      // PR-3e: inbound data now flows through IFramedTlsTransport.onData
-      // instead of socket.on('data') directly. The transport normalises the
-      // chunk to Buffer (never string) so we can drop the inner Buffer.from
-      // conversion. The transport is wrapped on `socket` just below this
-      // block; we set up the subscription AFTER constructing the transport
-      // for clarity. To preserve the previous registration order, we attach
-      // listeners on socket first and wire the transport's onData after the
-      // transport is constructed.
+      };
+      socket.on('secureConnect', onSecureConnect);
+      // PR-3e: inbound data now flows through IFramedTlsTransport.onData.
       const onInboundChunk = (chunk: Buffer): void => {
         commandMetricsStore.recordInboundMessage(this.host);
         this.state.lastActivityAt = Date.now();
         this.buffer = Buffer.concat([this.buffer, chunk]);
         this.flushBuffer();
       };
-      socket.on('error', fail);
-      socket.on('close', () => {
+      const onSocketError = (error: Error): void => {
+        fail(error);
+      };
+      const onSocketClose = (): void => {
         commandMetricsStore.recordSocketClosed(this.host);
         this.socket = undefined;
         this.protocolReady = false;
@@ -243,7 +249,7 @@ class NativeRemoteClient {
           settled = true;
           reject(new Error(`Could not connect to ${this.host}.`));
         }
-      });
+      };
 
       const finishProtocolHandshake = () => {
         if (settled) {
@@ -260,13 +266,16 @@ class NativeRemoteClient {
 
       socket.once('remote-protocol-ready', finishProtocolHandshake);
       this.socket = socket;
-      // PR-3d: wrap the live socket in the framed transport port now that it
-      // exists. Every send/drain call from here on goes through the port.
+      // PR-3d: wrap the live socket in the framed transport port.
       this.transport = createFramedTlsTransportOverSocket(socket);
-      // PR-3e: subscribe the inbound dispatch via the transport's onData.
-      // No need to track the unsubscribe handle — disconnect() destroys the
-      // socket, which Node's net layer cleans up via removeAllListeners.
+      // PR-3e: inbound data via transport.onData.
       this.transport.onData(onInboundChunk);
+      // PR-3f: lifecycle (error/close/timeout) via the transport contract.
+      // disconnect() destroys the socket which Node cleans up via
+      // removeAllListeners, so we don't track these unsubscribe handles.
+      this.transport.onError(onSocketError);
+      this.transport.onClose(onSocketClose);
+      this.transport.onTimeout(onSocketTimeout);
     }).finally(() => {
       this.connectPromise = undefined;
     });


### PR DESCRIPTION
## Summary

PR-3f of Wave 10. Completes the lifecycle side of the `IFramedTlsTransport` contract.

After this PR, the only `socket.on/once` calls left in `NativeRemoteClient` are the 2 **protocol-level** events (`remote-protocol-ready` and `remote-voice-begin`) that the client itself emits via `socket.emit(...)` inside `flushBuffer` — those are transport-internal synthesized events and intentionally stay on the raw socket.

## Contract additions to IFramedTlsTransport

```ts
onError(handler: (error: Error) => void): () => void
onClose(handler: () => void): () => void
onTimeout(handler: () => void): () => void
```

**The transport intentionally does NOT take ownership of timeout CONFIGURATION** (`socket.setTimeout(ms)`) since the value is protocol-specific — the caller (`NativeRemoteClient`) still configures the timeout duration via `socket.setTimeout(REMOTE_CONNECT_TIMEOUT_MS)`. Only the timeout EVENT is routed through the port.

## Production migration

```diff
- socket.on('timeout', () => { socket.destroy(...); });
- socket.on('error', fail);
- socket.on('close', () => { ... });
+ const onSocketTimeout = (): void => { socket.destroy(...); };
+ const onSocketError = (error: Error): void => { fail(error); };
+ const onSocketClose = (): void => { ... };
+ // ...
+ this.transport.onTimeout(onSocketTimeout);
+ this.transport.onError(onSocketError);
+ this.transport.onClose(onSocketClose);
```

`secureConnect` stays on the raw socket — it's a TLS-handshake event, not a transport-level event, and only updates `state.lastActivityAt`.

## Tests (+6 — total 226 → 232)

**Production binding (`createFramedTlsTransportOverSocket`):**

1. `onError subscribes via socket.on(error) and dispatches the error`
2. `onClose subscribes via socket.on(close) and dispatches with no payload`
3. `onTimeout subscribes via socket.on(timeout) and dispatches with no payload`
4. `lifecycle unsubscribes remove their respective listeners`

**Fake (`createFakeFramedTlsTransport`):**

5. `emitError/emitClose/emitTimeout dispatch to their respective subscribers`
6. `lifecycle unsubscribes stop further fake dispatches`

## Non-regression gate

**7th Google TV non-regression gate locked.** Any byte-level change to connection lifecycle handling now breaks the build before it can break a user:
- timeout → triggers `socket.destroy(new Error(...))`
- error → rejects the connect promise
- close → clears state and rejects the connect promise if pre-handshake

## Risk

**Medium.** Touches the `connect()` promise's error-handling paths. The new tests cover the contract; the production migration is a 1:1 rewire of the same handler bodies through the port.

Total chain: 24 merged + #85 + #86 + this = 27 from baseline.
