### PR TITLE
[low-risk] [NO-JIRA] refactor(updater): migrate download-started + download-progress sites to dispatchUpdaterEvent (PR-6e)

### DIFF
--- a/src/backend/updater/__tests__/updaterStatus.test.ts
+++ b/src/backend/updater/__tests__/updaterStatus.test.ts
@@ -170,7 +170,12 @@ describe('applyUpdaterEvent — every event transition', () => {
   it('download-started → downloading + zeros progress + clears eta + message includes version', () => {
     const after = applyUpdaterEvent(
       initial,
-      { type: 'download-progress', progressPercent: 99, etaSeconds: 4 },
+      {
+        type: 'download-progress',
+        progressPercent: 99,
+        etaSeconds: 4,
+        latestVersion: '1.2.3',
+      },
       V
     );
     const next = applyUpdaterEvent(after, { type: 'download-started', latestVersion: '2.0.0' }, V);
@@ -179,15 +184,55 @@ describe('applyUpdaterEvent — every event transition', () => {
     expect(next.message).toContain('2.0.0');
   });
 
-  it('download-progress → updates progress and eta only', () => {
+  it('download-started → caller-supplied message wins (PR-6e UX-parity)', () => {
     const next = applyUpdaterEvent(
       initial,
-      { type: 'download-progress', progressPercent: 42, etaSeconds: 17 },
+      {
+        type: 'download-started',
+        latestVersion: '2.0.0',
+        message: 'Downloading update 2.0.0...',
+      },
+      V
+    );
+    // ASCII "..." vs the default "Downloading X…" with ellipsis; caller wins.
+    expect(next.message).toBe('Downloading update 2.0.0...');
+  });
+
+  it('download-progress → sets stage:downloading + UX message + progress + eta (PR-6e)', () => {
+    const next = applyUpdaterEvent(
+      initial,
+      {
+        type: 'download-progress',
+        progressPercent: 42,
+        etaSeconds: 17,
+        latestVersion: '1.2.3',
+      },
       V
     );
     expect(next.progressPercent).toBe(42);
     expect(next.etaSeconds).toBe(17);
-    expect(next.stage).toBe(initial.stage); // unchanged
+    // PR-6e: stage and UX message are now derived from the event so the
+    // installAvailableUpdate progress callback doesn't have to set them
+    // inline. Matches the prior inline setUpdaterStatus shape.
+    expect(next.inProgress).toBe(true);
+    expect(next.stage).toBe('downloading');
+    expect(next.message).toBe('Downloading update 1.2.3... 42%');
+  });
+
+  it('download-progress → undefined progressPercent uses fallback message (PR-6e)', () => {
+    const next = applyUpdaterEvent(
+      initial,
+      {
+        type: 'download-progress',
+        progressPercent: undefined,
+        etaSeconds: undefined,
+        latestVersion: '1.2.3',
+      },
+      V
+    );
+    expect(next.progressPercent).toBeUndefined();
+    expect(next.etaSeconds).toBeUndefined();
+    expect(next.message).toBe('Downloading update 1.2.3...');
   });
 
   it('install-started / install-completed / install-failed transitions', () => {

--- a/src/backend/updater/updaterStatus.ts
+++ b/src/backend/updater/updaterStatus.ts
@@ -87,8 +87,13 @@ export type UpdaterEvent =
       installable: boolean;
       message: string;
     }
-  | { type: 'download-started'; latestVersion: string }
-  | { type: 'download-progress'; progressPercent: number; etaSeconds?: number }
+  | { type: 'download-started'; latestVersion: string; message?: string }
+  | {
+      type: 'download-progress';
+      progressPercent: number | undefined;
+      etaSeconds: number | undefined;
+      latestVersion: string;
+    }
   | { type: 'install-started' }
   | { type: 'install-completed'; latestVersion: string }
   | { type: 'install-failed'; message: string }
@@ -188,14 +193,33 @@ export function applyUpdaterEvent(
           stage: 'downloading',
           progressPercent: 0,
           etaSeconds: undefined,
-          message: `Downloading ${event.latestVersion}…`,
+          // PR-6e: caller-supplied message wins (matches existing inline
+          // setUpdaterStatus message format with ASCII "..." instead of "…")
+          // when migrating from installAvailableUpdate. Falls back to the
+          // PR-6 default ("Downloading X…") if omitted, so existing tests
+          // and any future caller that doesn't care about the format work.
+          message: event.message ?? `Downloading ${event.latestVersion}…`,
         },
         currentVersion
       );
     case 'download-progress':
+      // PR-6e: also keeps the "downloading" stage + UX message in sync with
+      // the inline setUpdaterStatus call. Without these, a download-progress
+      // event right after the user manually clicks "Check" would otherwise
+      // race the stage back to 'idle'. Message format ("Downloading X... NN%")
+      // matches what installAvailableUpdate's progress callback was sending.
       return mergeUpdaterStatus(
         prev,
-        { progressPercent: event.progressPercent, etaSeconds: event.etaSeconds },
+        {
+          inProgress: true,
+          stage: 'downloading',
+          progressPercent: event.progressPercent,
+          etaSeconds: event.etaSeconds,
+          message:
+            event.progressPercent !== undefined
+              ? `Downloading update ${event.latestVersion}... ${String(event.progressPercent)}%`
+              : `Downloading update ${event.latestVersion}...`,
+        },
         currentVersion
       );
     case 'install-started':

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -775,11 +775,12 @@ export async function installAvailableUpdate() {
   const tmpZipPath = path.join(os.tmpdir(), cachedAsset.name);
 
   try {
-    setUpdaterStatus({
-      inProgress: true,
-      stage: 'downloading',
-      progressPercent: 0,
-      etaSeconds: undefined,
+    // PR-6e: migrate to dispatchUpdaterEvent. Reducer was extended in this
+    // same PR to honor a caller-supplied message so the prior "Downloading
+    // update X..." (ASCII "...") format is preserved.
+    dispatchUpdaterEvent({
+      type: 'download-started',
+      latestVersion: version,
       message: `Downloading update ${version}...`,
     });
 
@@ -800,15 +801,13 @@ export async function installAvailableUpdate() {
             ? Math.min(100, Math.floor((downloadedBytes / totalBytes) * 100))
             : undefined;
 
-        setUpdaterStatus({
-          inProgress: true,
-          stage: 'downloading',
+        // PR-6e: migrate to dispatchUpdaterEvent. The reducer derives the
+        // exact same UX message + stage from `latestVersion + progressPercent`.
+        dispatchUpdaterEvent({
+          type: 'download-progress',
+          latestVersion: version,
           progressPercent,
           etaSeconds,
-          message:
-            progressPercent !== undefined
-              ? `Downloading update ${version}... ${String(progressPercent)}%`
-              : `Downloading update ${version}...`,
         });
       }
     );


### PR DESCRIPTION
## Summary

PR-6e of Wave 11. Continues the migration from inline `setUpdaterStatus(partial)` calls to typed `dispatchUpdaterEvent(event)`. Targets the 2 highest-value sites in `installAvailableUpdate`'s download phase.

## Migrations (2 call sites)

1. **`updater.ts:777`** — `installAvailableUpdate` download start → `dispatchUpdaterEvent({ type: 'download-started', latestVersion, message: 'Downloading update X...' })`.
2. **`updater.ts:802`** — `downloadFile` progress callback → `dispatchUpdaterEvent({ type: 'download-progress', latestVersion, progressPercent, etaSeconds })`. Eliminates a 6-field inline partial with derived UX message.

## Reducer revisions (zero UX change at migrated sites)

**`download-started`** — now accepts optional caller `message`. Falls back to the PR-6 default `'Downloading X…'`. Allows `installAvailableUpdate` to ship its prior ASCII `'Downloading update X...'` format unchanged.

**`download-progress`** — now also sets `inProgress: true` + `stage: 'downloading'` + a derived UX message: `'Downloading update X... N%'` (or no-% fallback when `progressPercent` is undefined). Matches what `installAvailableUpdate`'s progress callback was setting inline. `latestVersion` is now required so the message can include it without the reducer reaching for `prev.latestVersion`.

## Tests (+2 — total 233 → 235)

- `download-started → caller-supplied message wins (PR-6e UX-parity)`
- `download-progress → sets stage:downloading + UX message + progress + eta (PR-6e)`
- `download-progress → undefined progressPercent uses fallback message (PR-6e)`

(Pre-existing `download-progress → updates progress and eta only` assertion was replaced by the 2 new download-progress tests since the contract widened.)

## Migration scorecard

`setUpdaterStatus` inline calls migrated to date: **~10 of ~16 total**. Remaining ~6 are `install-started` / `install-completed` / `install-failed` + `rollback-*` flows (reducer variants already in place, need site-by-site migration).

## Risk

**Low.** Both inline sites are 1:1 swaps to events whose reducer output is byte-identical to the prior inline shape. UX UI sees byte-identical status snapshots before and after.

Total chain: 27 merged + this = 28 from baseline.
