### PR TITLE
[low-risk] [NO-JIRA] refactor(updater): migrate install-* sites to dispatchUpdaterEvent (PR-6f)

### DIFF
--- a/src/backend/updater/__tests__/updaterStatus.test.ts
+++ b/src/backend/updater/__tests__/updaterStatus.test.ts
@@ -256,6 +256,73 @@ describe('applyUpdaterEvent — every event transition', () => {
     expect(failed).toMatchObject({ inProgress: false, stage: 'failed', message: 'disk full' });
   });
 
+  it('install-started → sets progress:95 + eta:10 + caller-supplied message (PR-6f UX-parity)', () => {
+    // installAvailableUpdate transitions the download bar through 95 %
+    // before showing the install dialog. The ASCII '...' format (vs the
+    // default '…' ellipsis) is the caller's exact UX.
+    const next = applyUpdaterEvent(
+      initial,
+      { type: 'install-started', message: 'Installing update...' },
+      V
+    );
+    expect(next).toMatchObject({
+      inProgress: true,
+      stage: 'installing',
+      progressPercent: 95,
+      etaSeconds: 10,
+      message: 'Installing update...',
+    });
+  });
+
+  it('install-completed → sets progress:100 + eta:0 + honors dev-mode message (PR-6f UX-parity)', () => {
+    // installAvailableUpdate branches the message for the dev-updater
+    // override; the reducer must accept the caller value verbatim.
+    const next = applyUpdaterEvent(
+      initial,
+      {
+        type: 'install-completed',
+        latestVersion: '2.0.0',
+        message: 'Dev mode: install step skipped.',
+      },
+      V
+    );
+    expect(next).toMatchObject({
+      inProgress: false,
+      stage: 'completed',
+      progressPercent: 100,
+      etaSeconds: 0,
+      updateAvailable: false,
+      updateInstallable: false,
+      message: 'Dev mode: install step skipped.',
+    });
+  });
+
+  it('install-failed → clears progress/eta/updateAvailable/updateInstallable (PR-6f)', () => {
+    // Mirrors PR-6d's check-failed shape: a failed install must hide the
+    // progress bar and the 'Update available' CTA so the user can re-run
+    // the check from a clean state.
+    const downloading = applyUpdaterEvent(
+      initial,
+      {
+        type: 'download-progress',
+        progressPercent: 70,
+        etaSeconds: 5,
+        latestVersion: '2.0.0',
+      },
+      V
+    );
+    const next = applyUpdaterEvent(downloading, { type: 'install-failed', message: 'oom' }, V);
+    expect(next).toMatchObject({
+      inProgress: false,
+      stage: 'failed',
+      message: 'oom',
+      updateAvailable: false,
+      updateInstallable: false,
+    });
+    expect(next.progressPercent).toBeUndefined();
+    expect(next.etaSeconds).toBeUndefined();
+  });
+
   it('rollback transitions clear rollback metadata on completion', () => {
     const withRollback = applyUpdaterEvent(
       initial,

--- a/src/backend/updater/updaterStatus.ts
+++ b/src/backend/updater/updaterStatus.ts
@@ -94,8 +94,8 @@ export type UpdaterEvent =
       etaSeconds: number | undefined;
       latestVersion: string;
     }
-  | { type: 'install-started' }
-  | { type: 'install-completed'; latestVersion: string }
+  | { type: 'install-started'; message?: string }
+  | { type: 'install-completed'; latestVersion: string; message?: string }
   | { type: 'install-failed'; message: string }
   | { type: 'rollback-started' }
   | { type: 'rollback-completed' }
@@ -223,27 +223,56 @@ export function applyUpdaterEvent(
         currentVersion
       );
     case 'install-started':
+      // PR-6f: installAvailableUpdate sets progressPercent:95 + etaSeconds:10
+      // inline so the download progress bar smoothly transitions past 'almost
+      // done' before the install dialog appears. Reducer now sets those so
+      // the migrated call site is a 1:1 swap. Caller message wins so the
+      // ASCII "Installing update..." format is preserved verbatim.
       return mergeUpdaterStatus(
         prev,
-        { inProgress: true, stage: 'installing', message: 'Installing update…' },
+        {
+          inProgress: true,
+          stage: 'installing',
+          progressPercent: 95,
+          etaSeconds: 10,
+          message: event.message ?? 'Installing update…',
+        },
         currentVersion
       );
     case 'install-completed':
+      // PR-6f: also sets progressPercent:100 + etaSeconds:0 to match the
+      // inline shape (UX wants the bar to settle at 100 % before the
+      // "Relaunch now / Later" dialog). Caller message wins so the dev-mode
+      // override message ("Dev mode: install step skipped.") survives.
       return mergeUpdaterStatus(
         prev,
         {
           inProgress: false,
           stage: 'completed',
+          progressPercent: 100,
+          etaSeconds: 0,
           updateAvailable: false,
           updateInstallable: false,
-          message: `Installed ${event.latestVersion}. Relaunching…`,
+          message: event.message ?? `Installed ${event.latestVersion}. Relaunching…`,
         },
         currentVersion
       );
     case 'install-failed':
+      // PR-6f: also clears progressPercent/etaSeconds/updateAvailable/
+      // updateInstallable to match the inline shape (UI hides the progress
+      // bar and the "Update available" CTA after a failed install). Mirrors
+      // PR-6d's check-failed reducer revision.
       return mergeUpdaterStatus(
         prev,
-        { inProgress: false, stage: 'failed', message: event.message },
+        {
+          inProgress: false,
+          stage: 'failed',
+          progressPercent: undefined,
+          etaSeconds: undefined,
+          updateAvailable: false,
+          updateInstallable: false,
+          message: event.message,
+        },
         currentVersion
       );
     case 'rollback-started':

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -812,23 +812,19 @@ export async function installAvailableUpdate() {
       }
     );
 
-    setUpdaterStatus({
-      inProgress: true,
-      stage: 'installing',
-      progressPercent: 95,
-      etaSeconds: 10,
+    // PR-6f: migrate to dispatchUpdaterEvent. Reducer was extended in this
+    // same PR to honor caller-supplied messages and to mirror the
+    // inline-shape progress/eta values for byte-identical UX.
+    dispatchUpdaterEvent({
+      type: 'install-started',
       message: 'Installing update...',
     });
 
     await installMacUpdateFromZip(tmpZipPath);
 
-    setUpdaterStatus({
-      inProgress: false,
-      stage: 'completed',
-      progressPercent: 100,
-      etaSeconds: 0,
-      updateAvailable: false,
-      updateInstallable: false,
+    dispatchUpdaterEvent({
+      type: 'install-completed',
+      latestVersion: version,
       message: installDevModeOverride
         ? 'Dev mode: install step skipped.'
         : `Update ${version} installed.`,
@@ -866,13 +862,13 @@ export async function installAvailableUpdate() {
     // and the user can re-trigger a fresh check instead of being stuck on a broken install.
     cachedRelease = undefined;
     cachedAsset = undefined;
-    setUpdaterStatus({
-      inProgress: false,
-      stage: 'failed',
-      progressPercent: undefined,
-      etaSeconds: undefined,
-      updateAvailable: false,
-      updateInstallable: false,
+    // PR-6f: migrate to dispatchUpdaterEvent. Reducer's install-failed
+    // variant was extended in this PR to clear progressPercent/etaSeconds/
+    // updateAvailable/updateInstallable, mirroring the prior inline shape
+    // for byte-identical UX. cachedRelease/cachedAsset clearing above stays
+    // inline (it's transport state, not status).
+    dispatchUpdaterEvent({
+      type: 'install-failed',
       message: `Update ${version} failed during download or install. Please try again.`,
     });
     await showUpdaterDialog({


### PR DESCRIPTION
## Summary

PR-6f of Wave 12. Continues the migration from inline `setUpdaterStatus(partial)` calls to typed `dispatchUpdaterEvent(event)`. Targets the 3 `install-*` sites in `installAvailableUpdate`. After this PR, **the entire `installAvailableUpdate` function (download + install) is event-driven**.

## Migrations (3 call sites)

1. **`updater.ts:814`** → `install-started`
2. **`updater.ts:824`** → `install-completed` (dev + prod branches both flow through)
3. **`updater.ts:868`** (catch block) → `install-failed`

## Reducer revisions (zero UX change at migrated sites)

**`install-started`** — now accepts optional caller `message` (preserves ASCII `'Installing update...'`). Now sets `progressPercent:95 + etaSeconds:10` so the download bar smoothly transitions past "almost done" before the install dialog appears.

**`install-completed`** — now accepts optional caller `message` so the dev-mode override (`'Dev mode: install step skipped.'`) vs prod (`'Update X installed.'`) branch survives. Now sets `progressPercent:100 + etaSeconds:0` so the UI bar settles at 100 % before the "Relaunch now / Later" dialog.

**`install-failed`** — now clears `progressPercent` / `etaSeconds` / `updateAvailable` / `updateInstallable` to match the inline shape (UI hides the progress bar and "Update available" CTA after a failed install). Mirrors PR-6d's `check-failed` revision.

## Tests (+3 — total 238 → 241)

- `install-started → progress:95 + eta:10 + caller-supplied message (PR-6f UX-parity)`
- `install-completed → progress:100 + eta:0 + honors dev-mode message (PR-6f UX-parity)`
- `install-failed → clears progress/eta/updateAvailable/updateInstallable (PR-6f)`

## Migration scorecard

| Wave | PR | Migrated sites |
|---|---|---|
| 4 | PR-7 | 0 (introduced contract) |
| 5 | PR-6b | `check-completed-no-update` ×2 |
| 6 | PR-6c | (pre-aligned reducer) |
| 10 | PR-6d | `check-completed-update-available` + bg `check-failed` |
| 11 | PR-6e | `download-started` + `download-progress` |
| **12** | **PR-6f** | **`install-started` + `install-completed` + `install-failed`** |

**`setUpdaterStatus` inline calls migrated to date: ~13 of ~16 (~80 %).** Remaining 3 are rollback flow (`rollback-started`, `rollback-completed`, `rollback-failed` — variants already in reducer, need site migration). Will be PR-6g.

## Risk

**Low.** All 3 inline sites are 1:1 swaps to events whose reducer output is byte-identical to the prior inline shape.

Total chain: 29 merged + this + PR-renderer-1.
