### PR TITLE
[low-risk] [NO-JIRA] refactor(updater): migrate rollback-* sites + add rollback-unavailable variant (PR-6g)

### DIFF
--- a/src/backend/updater/__tests__/updaterStatus.test.ts
+++ b/src/backend/updater/__tests__/updaterStatus.test.ts
@@ -349,6 +349,125 @@ describe('applyUpdaterEvent — every event transition', () => {
     expect(next).toMatchObject({ inProgress: false, stage: 'failed', message: 'no backup' });
   });
 
+  it('rollback-started → progress:20 + caller message + targetVersion fallback (PR-6g)', () => {
+    // rollbackToPreviousVersion sets progressPercent:20 inline to show
+    // visible activity while the bundle restore runs. Caller message
+    // wins (ASCII '...' format from the prod call site).
+    const next = applyUpdaterEvent(
+      initial,
+      {
+        type: 'rollback-started',
+        targetVersion: '1.2.2',
+        message: 'Rolling back to 1.2.2...',
+        progressPercent: 20,
+      },
+      V
+    );
+    expect(next).toMatchObject({
+      inProgress: true,
+      stage: 'installing',
+      progressPercent: 20,
+      message: 'Rolling back to 1.2.2...',
+    });
+    expect(next.etaSeconds).toBeUndefined();
+
+    // Default fallback message uses ellipsis when caller omits one.
+    const defaulted = applyUpdaterEvent(
+      initial,
+      { type: 'rollback-started', targetVersion: '1.2.2' },
+      V
+    );
+    expect(defaulted.message).toContain('1.2.2');
+  });
+
+  it('rollback-completed → progress:100 + eta:0 + clears updateAvailable + honors dev-mode message (PR-6g)', () => {
+    // Dev-mode override branch from rollbackToPreviousVersion must
+    // survive the migration. Also clears updateAvailable/updateInstallable
+    // because any "update available" state from before the rollback no
+    // longer applies post-restore.
+    const dirty = applyUpdaterEvent(
+      initial,
+      {
+        type: 'check-completed-update-available',
+        latestVersion: '2.0.0',
+        lastCheckedAt: '2024-12-01T00:00:00Z',
+        installable: true,
+        message: 'Update 2.0.0 is available.',
+      },
+      V
+    );
+    const next = applyUpdaterEvent(
+      dirty,
+      {
+        type: 'rollback-completed',
+        message: 'Dev mode: rollback restore skipped.',
+      },
+      V
+    );
+    expect(next).toMatchObject({
+      inProgress: false,
+      stage: 'completed',
+      progressPercent: 100,
+      etaSeconds: 0,
+      updateAvailable: false,
+      updateInstallable: false,
+      message: 'Dev mode: rollback restore skipped.',
+    });
+  });
+
+  it('rollback-failed → clears progress/eta (PR-6g)', () => {
+    const inProgress = applyUpdaterEvent(
+      initial,
+      { type: 'rollback-started', targetVersion: '1.2.2', progressPercent: 20 },
+      V
+    );
+    const next = applyUpdaterEvent(
+      inProgress,
+      { type: 'rollback-failed', message: 'restore IO error' },
+      V
+    );
+    expect(next).toMatchObject({
+      inProgress: false,
+      stage: 'failed',
+      message: 'restore IO error',
+    });
+    expect(next.progressPercent).toBeUndefined();
+    expect(next.etaSeconds).toBeUndefined();
+  });
+
+  it('rollback-unavailable → stage:failed + clears rollback metadata + passes message (PR-6g)', () => {
+    // New variant: distinct from rollback-failed. Means there's no
+    // bundle to roll back to (vs an actual restore failure mid-op).
+    // Renderer can dim the rollback button instead of showing a red
+    // toast.
+    const withRollback = applyUpdaterEvent(
+      initial,
+      {
+        type: 'rollback-availability-changed',
+        available: true,
+        version: '1.1.0',
+        createdAt: '2024-11-01T00:00:00Z',
+      },
+      V
+    );
+    const next = applyUpdaterEvent(
+      withRollback,
+      {
+        type: 'rollback-unavailable',
+        message: 'No previous version backup is available.',
+      },
+      V
+    );
+    expect(next).toMatchObject({
+      inProgress: false,
+      stage: 'failed',
+      rollbackAvailable: false,
+      message: 'No previous version backup is available.',
+    });
+    expect(next.rollbackVersion).toBeUndefined();
+    expect(next.rollbackCreatedAt).toBeUndefined();
+  });
+
   it('rollback-availability-changed toggles availability fields independently of stage', () => {
     const enabled = applyUpdaterEvent(
       initial,

--- a/src/backend/updater/updaterStatus.ts
+++ b/src/backend/updater/updaterStatus.ts
@@ -97,9 +97,22 @@ export type UpdaterEvent =
   | { type: 'install-started'; message?: string }
   | { type: 'install-completed'; latestVersion: string; message?: string }
   | { type: 'install-failed'; message: string }
-  | { type: 'rollback-started' }
-  | { type: 'rollback-completed' }
+  | {
+      type: 'rollback-started';
+      targetVersion: string;
+      message?: string;
+      progressPercent?: number;
+    }
+  | { type: 'rollback-completed'; message?: string }
   | { type: 'rollback-failed'; message: string }
+  | {
+      // PR-6g: distinct from rollback-failed; triggered when there's no
+      // rollback bundle to roll back TO (vs an actual restore failure
+      // mid-operation). The renderer can present this differently
+      // (e.g. dim the rollback button instead of showing a red toast).
+      type: 'rollback-unavailable';
+      message: string;
+    }
   | {
       type: 'rollback-availability-changed';
       available: boolean;
@@ -276,28 +289,73 @@ export function applyUpdaterEvent(
         currentVersion
       );
     case 'rollback-started':
+      // PR-6g: rollbackToPreviousVersion sets progressPercent:20 inline
+      // to indicate visible activity while the bundle restore runs. The
+      // caller-supplied message ('Rolling back to X...') wins so the
+      // ASCII '...' UX format survives.
       return mergeUpdaterStatus(
         prev,
-        { inProgress: true, stage: 'installing', message: 'Rolling back to previous version…' },
+        {
+          inProgress: true,
+          stage: 'installing',
+          progressPercent: event.progressPercent ?? 20,
+          etaSeconds: undefined,
+          message: event.message ?? `Rolling back to ${event.targetVersion}…`,
+        },
         currentVersion
       );
     case 'rollback-completed':
+      // PR-6g: rollbackToPreviousVersion also sets progressPercent:100
+      // + etaSeconds:0 + clears updateAvailable/updateInstallable, since
+      // any 'update available' state from before the rollback no longer
+      // applies. Caller message wins so the dev-mode override
+      // ('Dev mode: rollback restore skipped.') survives.
       return mergeUpdaterStatus(
         prev,
         {
           inProgress: false,
           stage: 'completed',
+          progressPercent: 100,
+          etaSeconds: 0,
           rollbackAvailable: false,
           rollbackVersion: undefined,
           rollbackCreatedAt: undefined,
-          message: 'Rollback complete. Relaunching…',
+          updateAvailable: false,
+          updateInstallable: false,
+          message: event.message ?? 'Rollback complete. Relaunching…',
         },
         currentVersion
       );
     case 'rollback-failed':
+      // PR-6g: also clears progressPercent/etaSeconds to match the inline
+      // shape (UI hides the progress bar after a failed rollback). Mirrors
+      // PR-6f's install-failed reducer revision.
       return mergeUpdaterStatus(
         prev,
-        { inProgress: false, stage: 'failed', message: event.message },
+        {
+          inProgress: false,
+          stage: 'failed',
+          progressPercent: undefined,
+          etaSeconds: undefined,
+          message: event.message,
+        },
+        currentVersion
+      );
+    case 'rollback-unavailable':
+      // PR-6g: distinct outcome — no bundle to roll back to. Clear the
+      // stale rollback metadata so the UI's "rollback available" CTA
+      // disappears, set stage:'failed' so the renderer treats it as a
+      // user-visible error, and pass through the caller message.
+      return mergeUpdaterStatus(
+        prev,
+        {
+          inProgress: false,
+          stage: 'failed',
+          rollbackAvailable: false,
+          rollbackVersion: undefined,
+          rollbackCreatedAt: undefined,
+          message: event.message,
+        },
         currentVersion
       );
     case 'rollback-availability-changed':

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -890,7 +890,10 @@ export async function installAvailableUpdate() {
 
 export async function rollbackToPreviousVersion() {
   if (updaterStatus.inProgress) {
-    setUpdaterStatus({
+    // PR-6g: use the generic 'message' event (already in reducer) — only
+    // the UX message changes; no state machine transition needed here.
+    dispatchUpdaterEvent({
+      type: 'message',
       message: 'Cannot roll back while another update operation is in progress.',
     });
     return await getUpdaterStatus();
@@ -900,12 +903,11 @@ export async function rollbackToPreviousVersion() {
   const rollbackBundlePath = getRollbackBundlePath(state);
 
   if (!state.rollbackVersion || !rollbackBundlePath || !(await rollbackBundleExists(state))) {
-    setUpdaterStatus({
-      inProgress: false,
-      stage: 'failed',
-      rollbackAvailable: false,
-      rollbackVersion: undefined,
-      rollbackCreatedAt: undefined,
+    // PR-6g: use the new 'rollback-unavailable' variant introduced in
+    // this PR. Reducer clears the stale rollback metadata identically to
+    // the prior inline shape.
+    dispatchUpdaterEvent({
+      type: 'rollback-unavailable',
       message: 'No previous version backup is available.',
     });
     return await getUpdaterStatus();
@@ -929,12 +931,15 @@ export async function rollbackToPreviousVersion() {
   const targetBundle = getBundlePathFromExecPath();
 
   try {
-    setUpdaterStatus({
-      inProgress: true,
-      stage: 'installing',
-      progressPercent: 20,
-      etaSeconds: undefined,
+    // PR-6g: migrate to dispatchUpdaterEvent. Reducer's rollback-started
+    // variant was extended in this PR to accept progressPercent + caller
+    // message so the prior inline shape (progressPercent:20, ASCII '...')
+    // survives byte-identically.
+    dispatchUpdaterEvent({
+      type: 'rollback-started',
+      targetVersion: state.rollbackVersion,
       message: `Rolling back to ${state.rollbackVersion}...`,
+      progressPercent: 20,
     });
 
     await logInfo('updater', 'Restoring rollback backup', {
@@ -959,16 +964,12 @@ export async function rollbackToPreviousVersion() {
     }
 
     await clearRollbackBackup(state);
-    setUpdaterStatus({
-      inProgress: false,
-      stage: 'completed',
-      progressPercent: 100,
-      etaSeconds: 0,
-      rollbackAvailable: false,
-      rollbackVersion: undefined,
-      rollbackCreatedAt: undefined,
-      updateAvailable: false,
-      updateInstallable: false,
+    // PR-6g: migrate to dispatchUpdaterEvent. Reducer was extended in
+    // this PR to set the 5 cleared fields (progress/eta/updateAvailable/
+    // updateInstallable + rollback*) and accept the caller's
+    // dev-mode-vs-prod message branch verbatim.
+    dispatchUpdaterEvent({
+      type: 'rollback-completed',
       message: devModeOverride
         ? 'Dev mode: rollback restore skipped.'
         : `Rolled back to ${state.rollbackVersion}.`,
@@ -1002,11 +1003,11 @@ export async function rollbackToPreviousVersion() {
     }
   } catch (error) {
     await logError('updater', 'Rollback failed', error);
-    setUpdaterStatus({
-      inProgress: false,
-      stage: 'failed',
-      progressPercent: undefined,
-      etaSeconds: undefined,
+    // PR-6g: migrate to dispatchUpdaterEvent. Reducer's rollback-failed
+    // variant was extended in this PR to clear progress/eta inline so
+    // the UI hides the progress bar after a failed rollback.
+    dispatchUpdaterEvent({
+      type: 'rollback-failed',
       message: 'Rollback failed while restoring the previous version.',
     });
   }


### PR DESCRIPTION
## Summary

PR-6g of Wave 13. Closes out the `rollback-*` migrations (the last big chunk in `rollbackToPreviousVersion`). After this PR, **every status-machine transition in `checkForMacUpdate` + `installAvailableUpdate` + `rollbackToPreviousVersion`** — the 3 main user-facing flows — goes through `dispatchUpdaterEvent`.

## Migrations (5 call sites)

| Line | Before | After |
|---|---|---|
| 893 | `setUpdaterStatus({ message: ... })` (rejection) | `dispatchUpdaterEvent({ type: 'message', ... })` |
| 903 | inline (no rollback bundle) | NEW `dispatchUpdaterEvent({ type: 'rollback-unavailable', ... })` |
| 932 | inline (rollback start) | `dispatchUpdaterEvent({ type: 'rollback-started', targetVersion, progressPercent: 20, ... })` |
| 962 | inline (rollback complete) | `dispatchUpdaterEvent({ type: 'rollback-completed', message: ... })` |
| 1005 | inline (rollback failure) | `dispatchUpdaterEvent({ type: 'rollback-failed', message: ... })` |

## Reducer revisions (zero UX change at migrated sites)

**`rollback-started`** — now requires `targetVersion`, accepts optional `progressPercent` (defaults `20`) + `message`. `etaSeconds: undefined` set explicitly. Caller message wins (preserves ASCII `'...'` from prod call site).

**`rollback-completed`** — now accepts optional caller `message` (preserves dev-mode override `'Dev mode: rollback restore skipped.'`). Now also sets `progressPercent:100 + etaSeconds:0 + clears updateAvailable + updateInstallable` since any "update available" state from before the rollback no longer applies post-restore.

**`rollback-failed`** — now also clears `progressPercent + etaSeconds` to match the inline shape (UI hides the progress bar). Mirrors PR-6f's `install-failed` revision.

**`rollback-unavailable`** *(NEW variant)* — distinct from `rollback-failed`: means there's no bundle to roll back TO (vs an actual restore failure mid-operation). Clears stale rollback metadata, sets `stage:'failed'`, passes through caller message. Lets the renderer dim the rollback button instead of showing a red toast.

## Tests (+4 — total 270 → 274)

- `rollback-started → progress:20 + caller message + targetVersion fallback`
- `rollback-completed → progress:100 + eta:0 + clears updateAvailable + honors dev-mode message`
- `rollback-failed → clears progress/eta`
- `rollback-unavailable → stage:failed + clears rollback metadata + passes message`

## Migration scorecard

`setUpdaterStatus` inline calls: **15 → 10** (~62 % migrated to `dispatchUpdaterEvent`). Remaining 10 sites are non-status-machine paths (rollback flag toggles in `clearRollbackBackup` + `syncRollbackStatus`, pre-check status reset, error/fallback edges). Candidates for PR-6h or for keeping inline as direct status patches (they don't represent user-visible state transitions).

## Risk

**Low.** All 5 inline sites are 1:1 swaps to events whose reducer output is byte-identical to the prior inline shape.

Total chain: 31 merged + this + 2 sibling PRs in Wave 13.
