### PR TITLE
[low-risk] [NO-JIRA] refactor(eslint): add hard layer boundary rules (PR-boundaries)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -3,6 +3,11 @@ import js from '@eslint/js';
 import prettierConfig from 'eslint-config-prettier';
 import importPlugin from 'eslint-plugin-import-x';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
+// PR-boundaries (Wave 14): hard layer boundary enforcement via
+// no-restricted-imports rules scoped per layer. The eslint-plugin-boundaries
+// package is not actually used at runtime (we use no-restricted-imports
+// directly which is simpler and type-safe), but it's kept as a devDependency
+// as a signal of intent and for future graph-based rules.
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
@@ -196,6 +201,71 @@ export default tseslint.config(
       'tailwind.config.ts',
     ],
     extends: [tseslint.configs.disableTypeChecked],
+  },
+
+  // ── Backend layer boundary (PR-boundaries, Wave 14) ──────────────────────
+  // src/backend/** must NEVER import from electron, react, renderer, or main.
+  // Violations are reported as errors so they block CI.
+  {
+    files: ['src/backend/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['electron', 'electron/*'],
+              message:
+                'src/backend/ must not import from electron. Use a port interface (IFileSystem, ILogger, etc.) instead.',
+            },
+            {
+              group: ['react', 'react/*', 'react-dom', 'react-dom/*'],
+              message: 'src/backend/ must not import from React.',
+            },
+            {
+              group: ['**/renderer/**', '../renderer/**', '../../renderer/**'],
+              message: 'src/backend/ must not import from the renderer layer.',
+            },
+            {
+              group: ['**/main/**', '../main/**', '../../main/**'],
+              message:
+                'src/backend/ must not import from src/main/. If you need something from main, expose it via a port interface.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // ── Renderer layer boundary (PR-boundaries, Wave 14) ─────────────────────
+  // src/renderer/** must NEVER import from src/backend/ or src/main/.
+  // Renderer talks to main ONLY through window.gtvRemote (the IPC surface
+  // defined in shared/ipcContract.ts + preload.ts).
+  {
+    files: ['src/renderer/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/backend/**', '../backend/**', '../../backend/**'],
+              message:
+                'src/renderer/ must not import from src/backend/. Use the IPC bridge (window.gtvRemote) instead.',
+            },
+            {
+              group: ['**/main/**', '../main/**', '../../main/**'],
+              message:
+                'src/renderer/ must not import from src/main/. Use the IPC bridge (window.gtvRemote) instead.',
+            },
+            {
+              group: ['electron', 'electron/*'],
+              message: 'src/renderer/ must not import from electron directly.',
+            },
+          ],
+        },
+      ],
+    },
   },
 
   // ── Prettier must be last to disable formatting rules ─────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "electron-builder": "^26.0.12",
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-boundaries": "^5.4.0",
         "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-react-hooks": "^7.1.1",
         "husky": "^9.1.7",
@@ -402,6 +403,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@boundaries/elements": {
+      "version": "1.2.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@boundaries/elements/-/elements-1.2.0.tgz",
+      "integrity": "sha512-W65Gum02liMd3hmNrLmDBX1u5BmRMcunouFjLXyhxHnNY4YlK1kTxsgfflZ5XBGSnPnO0MkiUzAcoGzYrlx0RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-import-resolver-node": "0.3.9",
+        "eslint-module-utils": "2.12.1",
+        "handlebars": "4.7.8",
+        "is-core-module": "2.16.1",
+        "micromatch": "4.0.8"
+      },
+      "engines": {
+        "node": ">=18.18"
+      }
+    },
+    "node_modules/@boundaries/elements/node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
       }
     },
     "node_modules/@colors/colors": {
@@ -8153,6 +8193,76 @@
         }
       }
     },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-boundaries": {
+      "version": "5.4.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/eslint-plugin-boundaries/-/eslint-plugin-boundaries-5.4.0.tgz",
+      "integrity": "sha512-6SQmEhXCqGrrxm9YiM24SC95CqrVi2MUOm5SDrfquceh/os8MIAvZYsDU69zvtCSb1S6UbNEmdioi1gCDc8+VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@boundaries/elements": "1.2.0",
+        "chalk": "4.1.2",
+        "eslint-import-resolver-node": "0.3.9",
+        "eslint-module-utils": "2.12.1",
+        "micromatch": "4.0.8"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-plugin-import-x": {
       "version": "4.16.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
@@ -9555,6 +9665,22 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -13884,6 +14010,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -14677,6 +14810,28 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-alpn": {
@@ -16122,6 +16277,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "electron-builder": "^26.0.12",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-boundaries": "^5.4.0",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-react-hooks": "^7.1.1",
     "husky": "^9.1.7",


### PR DESCRIPTION
## Summary

Wave 14 / PR-boundaries. Adds `no-restricted-imports` rules scoped per architectural layer to make layer boundary violations CI-visible errors rather than conventions that get silently violated over time.

## Rules added

### `src/backend/**`
Cannot import: `electron/*` · `react` · `react-dom` · `**/renderer/**` · `**/main/**`

**Why**: backend modules must be pure Node; Electron/React coupling belongs in `main/` or `renderer/` respectively. Any cross-cutting concern must go through a port interface (`IFileSystem`, `ILogger`, `IClock`, etc.) — the pattern established across Waves 0–13.

### `src/renderer/**`
Cannot import: `**/backend/**` · `**/main/**` · `electron`

**Why**: renderer is a thin React shell; it talks to main **only** through `window.gtvRemote` (the IPC surface defined in `shared/ipcContract.ts` + `preload.ts`). Direct backend imports would bypass the IPC bridge.

## Existing violations: 0

The refactor waves 0–13 have already placed every backend import behind port interfaces, so the new rules land cleanly on the current codebase.

## What this does NOT restrict (intentional)

- `src/main/**` may import from `src/backend/**` (that's the composition root pattern — `GoogleTvAdapter` + `AppFacade` wire the backend services together inside main).
- `src/shared/**` is unrestricted (it's the explicit cross-layer contract layer).

## Risk: **low** — config-only change, 0 violations on current codebase.
