### PR TITLE
fix(mac): ad-hoc sign release builds for Gatekeeper

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
         "dmg",
         "zip"
       ],
+      "identity": "-",
+      "hardenedRuntime": false,
       "category": "public.app-category.utilities",
       "icon": "taskbar-icon.icns",
       "extendInfo": {


### PR DESCRIPTION
## Problem

CI has no signing certificate, so electron-builder skips signing the app
bundle. This causes quarantined installs to show "GTV Remote is damaged
and can't be opened" instead of offering "Open Anyway".

## Fix

Use explicit ad-hoc signing (`identity: "-"`) and disable hardened runtime
for ad-hoc builds.

## Verification

Verified on Apple Silicon that the bundle is properly sealed and that
Gatekeeper offers **Open Anyway** for a quarantined install.
