### PR TITLE
fix(discovery): decode dns-sd escapes and raw whitespace in device names

### DIFF
--- a/src/backend/devices/__tests__/dnsSdText.test.ts
+++ b/src/backend/devices/__tests__/dnsSdText.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodeDnsSdValue, parseDnsSdTxtLine } from '../dnsSdText';
+
+const NBSP = '\u00a0';
+
+describe('decodeDnsSdValue', () => {
+  it('decodes escaped quotes, spaces, and backslashes', () => {
+    expect(decodeDnsSdValue('55\\"\\ Neo\\ QLED')).toBe('55" Neo QLED');
+    expect(decodeDnsSdValue('a\\\\b')).toBe('a\\b');
+  });
+
+  it('decodes decimal \\DDD escapes', () => {
+    expect(decodeDnsSdValue('Neo\\032QLED')).toBe('Neo QLED');
+    expect(decodeDnsSdValue('tab\\009end')).toBe('tab\tend');
+  });
+
+  it('leaves unescaped text untouched', () => {
+    expect(decodeDnsSdValue('QN80D')).toBe('QN80D');
+  });
+});
+
+describe('parseDnsSdTxtLine', () => {
+  // Captured verbatim from `dns-sd -L` output of real TVs.
+  const samsungLine =
+    ' id=300401e0c8d6e744e5e01c8a7a407fe4 fn=55\\"\\ Neo\\ QLED md=QN80D ic=/setup/icon.png ve=05 st=3';
+
+  it('unescapes quotes inside values', () => {
+    const txt = parseDnsSdTxtLine(samsungLine);
+    expect(txt.fn).toBe('55" Neo QLED');
+    expect(txt.md).toBe('QN80D');
+    expect(txt.ic).toBe('/setup/icon.png');
+  });
+
+  it('keeps values with raw unescaped whitespace intact', () => {
+    // dns-sd publishes the no-break space (U+00A0) raw, not escaped.
+    const txt = parseDnsSdTxtLine(` fn=Televize\\ v${NBSP}obýváku md=Smart\\ TV\\ Pro st=0`);
+    expect(txt.fn).toBe(`Televize v${NBSP}obýváku`);
+    expect(txt.md).toBe('Smart TV Pro');
+    expect(txt.st).toBe('0');
+  });
+
+  it('does not split values on an escaped space before a key-like token', () => {
+    expect(parseDnsSdTxtLine(' fn=abc\\ md=X st=0')).toEqual({ fn: 'abc md=X', st: '0' });
+  });
+
+  it('ignores lines without valid key=value tokens', () => {
+    expect(parseDnsSdTxtLine('   ')).toEqual({});
+    expect(parseDnsSdTxtLine('DATE: ---Sun 16 Aug 2026---')).toEqual({});
+  });
+});

--- a/src/backend/devices/dnsSdText.ts
+++ b/src/backend/devices/dnsSdText.ts
@@ -1,0 +1,42 @@
+/**
+ * Helpers for parsing the text output of the macOS `dns-sd` tool.
+ *
+ * `dns-sd` prints mDNS data in DNS presentation format: ASCII specials are
+ * backslash-escaped (`\ `, `\"`, `\\`), non-printable bytes appear as decimal
+ * `\DDD`, and non-ASCII UTF-8 bytes — including U+00A0 no-break space — pass
+ * through raw. TXT values can therefore contain unescaped whitespace, so a
+ * value only ends where the next `key=` token begins.
+ */
+
+/** Decode dns-sd's DNS presentation escaping: decimal `\DDD` and `\X` → `X`. */
+export function decodeDnsSdValue(value: string): string {
+  return value.replace(/\\(\d{3}|.)/g, (_match, escaped: string) =>
+    /^\d{3}$/.test(escaped) ? String.fromCharCode(Number(escaped)) : escaped
+  );
+}
+
+/**
+ * Parse one TXT-record line of `dns-sd -L` output into key/value pairs.
+ * Values may contain raw (unescaped) whitespace — real TVs publish names like
+ * `fn=Televize\ v<NBSP>obývaku` — so entries are split only where a whitespace
+ * run is followed by the next `key=` token.
+ */
+export function parseDnsSdTxtLine(line: string): Record<string, string> {
+  const txt: Record<string, string> = {};
+
+  for (const entry of line.trim().split(/(?<!\\)\s+(?=[A-Za-z0-9_-]+=)/)) {
+    const separator = entry.indexOf('=');
+    if (separator <= 0) {
+      continue;
+    }
+
+    const key = entry.slice(0, separator);
+    if (!/^[A-Za-z0-9_-]+$/.test(key)) {
+      continue;
+    }
+
+    txt[key] = decodeDnsSdValue(entry.slice(separator + 1));
+  }
+
+  return txt;
+}

--- a/src/main/device/discovery.ts
+++ b/src/main/device/discovery.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 
+import { decodeDnsSdValue, parseDnsSdTxtLine } from '../../backend/devices/dnsSdText';
 import type { DiscoveredDevice } from '../../shared/types';
 import { record } from '../capture';
 
@@ -10,10 +11,6 @@ interface ResolvedService {
   host?: string;
   port?: number;
   txt: Record<string, string>;
-}
-
-function decodeDnsSdValue(value: string): string {
-  return value.replace(/\\032/g, ' ').replace(/\\ /g, ' ').replace(/\\\\/g, '\\');
 }
 
 function buildDiscoveredId(host: string, name: string): string {
@@ -105,25 +102,6 @@ async function browseServiceInstances(serviceType: string, timeoutMs = 2500): Pr
   return [...instances];
 }
 
-function parseTxtRecord(line: string): Record<string, string> {
-  const txt: Record<string, string> = {};
-  const matches = line.match(/(?:^|\s)([A-Za-z0-9_-]+)=((?:\\.|[^\s])*)/g) ?? [];
-
-  for (const entry of matches) {
-    const trimmed = entry.trim();
-    const separator = trimmed.indexOf('=');
-    if (separator === -1) {
-      continue;
-    }
-
-    const key = trimmed.slice(0, separator);
-    const value = trimmed.slice(separator + 1);
-    txt[key] = decodeDnsSdValue(value);
-  }
-
-  return txt;
-}
-
 async function resolveService(
   instanceName: string,
   serviceType: string
@@ -143,7 +121,7 @@ async function resolveService(
     }
 
     if (line.includes('=')) {
-      txt = { ...txt, ...parseTxtRecord(line) };
+      txt = { ...txt, ...parseDnsSdTxtLine(line) };
     }
   }
 
@@ -254,7 +232,7 @@ export async function discoverGoogleTvDevices(): Promise<DiscoveredDevice[]> {
     const remoteService = remoteByHost.get(service.host);
     const connectService = connectByHost.get(service.host);
     const pairService = pairingByHost.get(service.host);
-    const name = service.txt.fn || service.instanceName;
+    const name = service.txt.fn || decodeDnsSdValue(service.instanceName);
 
     devices.set(service.host, {
       id: existing?.id ?? buildDiscoveredId(service.host, name),


### PR DESCRIPTION
## Problem

The `dns-sd` parser mishandles escaped characters and raw whitespace in
TV names, causing names to be rendered incorrectly or truncated.

## Fix

Decode DNS-SD escapes and split TXT entries only at `key=` boundaries.
Add unit tests using captured `dns-sd` output.
